### PR TITLE
add a timeout to videoplayer when nothing is playing for more than 60 seconds

### DIFF
--- a/ovos_workshop/res/ui/VideoPlayer.qml
+++ b/ovos_workshop/res/ui/VideoPlayer.qml
@@ -29,6 +29,7 @@ Mycroft.Delegate {
     
     Component.onCompleted: {
         syncStatusTimer.restart()
+        idleCheckTimer.restart()
     }
     
     Keys.onDownPressed: {
@@ -78,6 +79,17 @@ Mycroft.Delegate {
     
     Timer {
         id: delaytimer
+    }
+
+    Timer {
+        id: idleCheckTimer
+        interval: 60000
+        repeat: true
+        onTriggered {
+            if (!MediaPlayer.PlayingState || !MediaPlayer.PausedState) {
+                triggerGuiEvent("video.media.playback.ended", {})
+            }
+        }
     }
 
     function delay(delayTime, cb) {


### PR DESCRIPTION
Video Player: Add a timeout when the media is not in a playing or paused state for more than 60 seconds and try return to homescreen