### PR TITLE
remove forced focus event to allow page swipes

### DIFF
--- a/ovos_workshop/res/ui/OVOSVideoPlayer.qml
+++ b/ovos_workshop/res/ui/OVOSVideoPlayer.qml
@@ -62,10 +62,6 @@ Mycroft.Delegate {
         controlBarItem.forceActiveFocus()
     }
 
-    onFocusChanged: {
-        video.forceActiveFocus();
-    }
-
     onVideoSourceChanged: {
         root.play()
         delay(6000, function() {


### PR DESCRIPTION
Removes forced focus event to allow page swipe to work correctly