### PR TITLE
move OCP to optional requirements

### DIFF
--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -4,6 +4,10 @@ from ovos_workshop.decorators.layers import enables_layer, \
     disables_layer, layer_intent, removes_layer, resets_layers, replaces_layer
 from ovos_workshop.decorators.converse import converse_handler
 from ovos_workshop.decorators.fallback_handler import fallback_handler
+try:
+    from ovos_workshop.decorators.ocp import ocp_next, ocp_play, ocp_pause, ocp_resume, ocp_search, ocp_previous, ocp_featured_media
+except ImportError:
+    pass  # these imports are only available if extra requirements are installed
 
 
 def resting_screen_handler(name):

--- a/requirements/ocp.txt
+++ b/requirements/ocp.txt
@@ -1,0 +1,1 @@
+ovos_plugin_common_play

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
 ovos_utils~=0.0, >=0.0.23
 ovos_config~=0.0,>=0.0.4
-ovos_plugin_common_play
 
 # optional but improves fuzzy matching and silences logs
 rapidfuzz

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
               'ovos_workshop.decorators',
               'ovos_workshop.patches'],
     install_requires=required("requirements/requirements.txt"),
+    extras_require={
+            'ocp': required('requirements/ocp.txt')
+        },
     package_data={'': package_files('ovos_workshop')},
     url='https://github.com/OpenVoiceOS/OVOS-workshop',
     license='apache-2.0',


### PR DESCRIPTION
 only needed for OCP skills that directly import the template
 
 solves cyclic imports in dependencies