### PR TITLE
Get response from validated value

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -368,14 +368,16 @@ class OVOSSkill(MycroftSkill):
                     self._response = None
                     return
             else:
-                if validator(response):
-                    self._response = response
-                    return
-
                 # catch user saying 'cancel'
                 if is_cancel(response):
                     self._response = None
                     return
+                validated = validator(response)
+                # returns the validated value or the response
+                # (backwards compat)
+                if validated is not False and validated is not None:
+                    self._response = response if validated is True else validated
+                    return                
 
             num_fails += 1
             if 0 < num_retries < num_fails or self._response is not False:


### PR DESCRIPTION
Problem: the validator as is returns the response. This is cumbersome, because sometimes you have to do things twice.
As a simple example, you want to ensure a datetime from a response you have to extract it once in the validator and the second time in the calling function to get the datetime.

This addition will optionally return the validated value if not `True` is returned from the validator (if `True` the original response; backwards compat)

If the validated value is `False` or `None` it depends on `num_retries` how to proceed. (if to ask again or return None)