### PR TITLE
Deprecate Application-managed `settings`

### DIFF
--- a/ovos_workshop/app.py
+++ b/ovos_workshop/app.py
@@ -2,6 +2,7 @@ from os.path import isdir, join
 
 from ovos_config.locations import get_xdg_config_save_path
 from ovos_utils.messagebus import get_mycroft_bus
+from ovos_utils.log import LOG
 
 from ovos_workshop.resource_files import locate_lang_directories
 from ovos_workshop.skills.ovos import OVOSSkill
@@ -10,8 +11,10 @@ from ovos_workshop.skills.ovos import OVOSSkill
 class OVOSAbstractApplication(OVOSSkill):
     def __init__(self, skill_id, bus=None, resources_dir=None,
                  lang=None, settings=None, gui=None, enable_settings_manager=False):
-        super().__init__(bus=bus, gui=gui, settings=settings,
-                         resources_dir=resources_dir,
+        if settings:
+            LOG.error("settings arg is deprecated and will be ignored. You may"
+                      "update settings after Application init")
+        super().__init__(bus=bus, gui=gui, resources_dir=resources_dir,
                          enable_settings_manager=enable_settings_manager)
         self.skill_id = skill_id
         self._dedicated_bus = False

--- a/ovos_workshop/app.py
+++ b/ovos_workshop/app.py
@@ -11,11 +11,12 @@ from ovos_workshop.skills.ovos import OVOSSkill
 class OVOSAbstractApplication(OVOSSkill):
     def __init__(self, skill_id, bus=None, resources_dir=None,
                  lang=None, settings=None, gui=None, enable_settings_manager=False):
-        if settings:
-            LOG.error("settings arg is deprecated and will be ignored. You may"
-                      "update settings after Application init")
         super().__init__(bus=bus, gui=gui, resources_dir=resources_dir,
                          enable_settings_manager=enable_settings_manager)
+        if settings:
+            LOG.warning("settings arg is deprecated and will be removed "
+                        "in a future release")
+            self.settings.merge(settings)
         self.skill_id = skill_id
         self._dedicated_bus = False
         if bus:

--- a/ovos_workshop/app.py
+++ b/ovos_workshop/app.py
@@ -13,10 +13,6 @@ class OVOSAbstractApplication(OVOSSkill):
                  lang=None, settings=None, gui=None, enable_settings_manager=False):
         super().__init__(bus=bus, gui=gui, resources_dir=resources_dir,
                          enable_settings_manager=enable_settings_manager)
-        if settings:
-            LOG.warning("settings arg is deprecated and will be removed "
-                        "in a future release")
-            self.settings.merge(settings)
         self.skill_id = skill_id
         self._dedicated_bus = False
         if bus:
@@ -25,6 +21,10 @@ class OVOSAbstractApplication(OVOSSkill):
             self._dedicated_bus = True
             bus = get_mycroft_bus()
         self._startup(bus, skill_id)
+        if settings:
+            LOG.warning("settings arg is deprecated and will be removed "
+                        "in a future release")
+            self.settings.merge(settings)
 
     @property
     def _settings_path(self):

--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -129,8 +129,8 @@ class BaseSkill:
         #: Mycroft global configuration. (dict)
         self.config_core = Configuration()
 
-        self._settings = settings
-        self._initial_settings = {}
+        self._settings = None
+        self._initial_settings = settings or dict()
         self._settings_watchdog = None
 
         #: Set to register a callback method that will be called every time
@@ -248,12 +248,7 @@ class BaseSkill:
 
             # initialize anything that depends on skill_id
             self.log = LOG.create_logger(self.skill_id)
-            if self._settings and isinstance(self._settings, JsonStorage):
-                LOG.warning(f"Passing settings to __init__ is deprecated and"
-                            f"will be removed in an upcoming release")
-            else:
-                LOG.debug(f"Initializing settings file")
-                self._init_settings()
+            self._init_settings()
 
             # initialize anything that depends on the messagebus
             self.bind(bus)
@@ -287,7 +282,8 @@ class BaseSkill:
         if self._initial_settings:
             # TODO make a debug log in next version
             LOG.warning("Copying default settings values defined in __init__ \n"
-                        "Please move code from __init__() to initialize() if you did not expect to see this message")
+                        "Please move code from __init__() to initialize() "
+                        "if you did not expect to see this message")
             for k, v in self._initial_settings.items():
                 if k not in self._settings:
                     self._settings[k] = v

--- a/test/unittests/test_abstract_app.py
+++ b/test/unittests/test_abstract_app.py
@@ -34,7 +34,6 @@ class TestApp(unittest.TestCase):
     def test_settings_init(self):
         self.assertNotEqual(self.app.settings, self.settings_obj)
         self.assertFalse(self.app.settings['__mycroft_skill_firstrun'])
-        self.app.settings.update(self.settings)
         self.assertTrue(self.app.settings['test'])
         self.assertFalse(self.app.settings['updated'])
         self.settings_obj['updated'] = True

--- a/test/unittests/test_abstract_app.py
+++ b/test/unittests/test_abstract_app.py
@@ -31,12 +31,14 @@ class TestApp(unittest.TestCase):
                               settings=cls.settings_obj, gui=cls.gui)
         cls.app._startup(cls.bus)
 
-
     def test_settings_init(self):
-        self.assertEqual(self.app.settings, self.settings_obj)
+        self.assertNotEqual(self.app.settings, self.settings_obj)
         self.assertFalse(self.app.settings['__mycroft_skill_firstrun'])
+        self.app.settings.update(self.settings)
+        self.assertTrue(self.app.settings['test'])
+        self.assertFalse(self.app.settings['updated'])
         self.settings_obj['updated'] = True
-        self.assertEqual(self.app.settings, self.settings_obj)
+        self.assertFalse(self.app.settings['updated'])
 
     def test_settings_init_invalid_arg(self):
         app = Application(skill_id="TestApplication",

--- a/test/unittests/test_abstract_app.py
+++ b/test/unittests/test_abstract_app.py
@@ -31,9 +31,6 @@ class TestApp(unittest.TestCase):
                               settings=cls.settings_obj, gui=cls.gui)
         cls.app._startup(cls.bus)
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        remove(cls.test_path)
 
     def test_settings_init(self):
         self.assertEqual(self.app.settings, self.settings_obj)


### PR DESCRIPTION
Remove `settings` kwarg in OVOSAbstractApplication init and log error if passed
Update BaseSkill `settings` kwarg handling to use `_initial_settings`

Needs https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/pull/36