### PR TITLE
allow empty string value settings

### DIFF
--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -365,7 +365,7 @@ class BaseSkill:
             return
         # ensure self._settings remains a JsonDatabase
         self._settings.clear()  # clear data
-        self._settings.merge(val)  # merge new data
+        self._settings.merge(val, skip_empty=False)  # merge new data
 
     # not a property in mycroft-core
     @property


### PR DESCRIPTION
The settings setter was merging a new dict with skip_empty=True. This causes empty (faulty - except False) values to not being stored.

This fixes the issue.
