### PR TITLE
add `voc_list` helper function

### DIFF
--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -21,6 +21,7 @@ from copy import copy
 from dataclasses import dataclass
 from hashlib import md5
 from inspect import signature
+from typing import List
 from itertools import chain
 from os.path import join, abspath, dirname, basename, isfile
 from threading import Event
@@ -1048,18 +1049,8 @@ class BaseSkill:
         return resp
 
     # method not present in mycroft-core
-    def voc_list(self, voc_filename, lang=None):
-        """
-        Get vocabulary list and cache the results
+    def _voc_list(self, voc_filename, lang=None) -> List[str]:
 
-        Args:
-            voc_filename (str): Name of vocabulary file (e.g. 'yes' for
-                                'res/text/en-us/yes.voc')
-            lang (str): Language code, defaults to self.lang
-
-        Returns:
-            list: List of vocabulary found in voc_filename
-        """
         lang = lang or self.lang
         cache_key = lang + voc_filename
 
@@ -1094,7 +1085,7 @@ class BaseSkill:
             bool: True if the utterance has the given vocabulary it
         """
         match = False
-        _vocs = self.voc_list(voc_filename, lang)
+        _vocs = self._voc_list(voc_filename, lang)
 
         if utt and _vocs:
             if exact:

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -134,15 +134,9 @@ class OVOSSkill(MycroftSkill):
 
     def remove_voc(self, utt, voc_filename, lang=None):
         """ removes any entry in .voc file from the utterance """
-        lang = lang or self.lang
-        cache_key = lang + voc_filename
-
-        if cache_key not in self.voc_match_cache:
-            self.voc_match(utt, voc_filename, lang)
-
         if utt:
             # Check for matches against complete words
-            for i in self.voc_match_cache.get(cache_key) or []:
+            for i in self.voc_list(voc_filename, lang):
                 # Substitute only whole words matching the token
                 utt = re.sub(r'\b' + i + r"\b", "", utt)
 

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1,5 +1,6 @@
 import re
 import time
+from typing import List
 
 from ovos_utils.intents import IntentBuilder, Intent
 from ovos_utils.log import LOG
@@ -131,6 +132,20 @@ class OVOSSkill(MycroftSkill):
             return super().voc_match(*args, **kwargs)
         except FileNotFoundError:
             return False
+
+    def voc_list(self, voc_filename, lang=None) -> List[str]:
+        """
+        Get vocabulary list and cache the results
+
+        Args:
+            voc_filename (str): Name of vocabulary file (e.g. 'yes' for
+                                'res/text/en-us/yes.voc')
+            lang (str): Language code, defaults to self.lang
+
+        Returns:
+            list: List of vocabulary found in voc_filename
+        """
+        return self._voc_list(voc_filename, lang)
 
     def remove_voc(self, utt, voc_filename, lang=None):
         """ removes any entry in .voc file from the utterance """

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -442,7 +442,7 @@ class TestMycroftSkill(unittest.TestCase):
         s = SimpleSkill1()
         s.root_dir = abspath(dirname(__file__))
 
-        self.assertEqual(s.voc_list("turn_off_test"),
+        self.assertEqual(s._voc_list("turn_off_test"),
                          ["turn off", "switch off"])
         cache_key = s.lang+"turn_off_test"
         self.assertIn(cache_key, s._voc_cache)

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -437,6 +437,15 @@ class TestMycroftSkill(unittest.TestCase):
                                     exact=True))
         self.assertFalse(s.voc_match("would you please turn off the lights",
                                      "turn_off_test", exact=True))
+        
+    def test_voc_list(self):
+        s = SimpleSkill1()
+        s.root_dir = abspath(dirname(__file__))
+
+        self.assertEqual(s.voc_list("turn_off_test"),
+                         ["turn off", "switch off"])
+        cache_key = s.lang+"turn_off_test"
+        self.assertIn(cache_key, s._voc_cache)
 
     def test_translate_locations(self):
         """Assert that the a translatable list can be loaded from dialog and


### PR DESCRIPTION
this adds a helper function to get a list of skill vocabulary based on the lang passed.
* instead of `voc_match`, `voc_list` is now caching the vocabulary in the process
* `remove_voc` and `voc_match` are now sourcing the list from `voc_list` to remove/match vocabulary  

tests added for `voc_list`

closes #53 