### PR TITLE
feat/skill_launcher

### DIFF
--- a/ovos_workshop/skill_launcher.py
+++ b/ovos_workshop/skill_launcher.py
@@ -1,6 +1,7 @@
 import gc
 import importlib
 import os
+from os.path import isdir
 import sys
 from inspect import isclass
 from os import path, makedirs
@@ -473,6 +474,7 @@ class PluginSkillLoader(SkillLoader):
 
 
 def launch_plugin_skill(skill_id):
+    """ run a plugin skill standalone """
     bus = MessageBusClient()
     bus.run_in_thread()
     plugins = find_skill_plugins()
@@ -490,6 +492,7 @@ def launch_plugin_skill(skill_id):
 
 
 def launch_standalone_skill(skill_directory, skill_id):
+    """ run a skill standalone from a directory """
     bus = MessageBusClient()
     bus.run_in_thread()
     skill_loader = SkillLoader(bus, skill_directory,
@@ -504,7 +507,7 @@ def launch_standalone_skill(skill_directory, skill_id):
 
 
 def _launch_script():
-    from os.path import isdir
+    """USAGE: ovos-skill-launcher {skill_id} [path/to/my/skill_id]"""
     if (args_count := len(sys.argv)) == 2:
         skill_id = sys.argv[1]
 

--- a/ovos_workshop/skill_launcher.py
+++ b/ovos_workshop/skill_launcher.py
@@ -1,0 +1,584 @@
+import gc
+import importlib
+import os
+import sys
+from inspect import isclass
+from os import path, makedirs
+from time import time
+
+from ovos_bus_client.client import MessageBusClient
+from ovos_bus_client.message import Message
+from ovos_config.config import Configuration
+from ovos_config.locations import get_xdg_data_dirs, get_xdg_data_save_path
+from ovos_plugin_manager.skills import find_skill_plugins
+from ovos_utils import wait_for_exit_signal
+from ovos_utils.file_utils import FileWatcher
+from ovos_utils.log import LOG
+from ovos_utils.process_utils import RuntimeRequirements
+
+from ovos_workshop.skills.active import ActiveSkill
+from ovos_workshop.skills.auto_translatable import UniversalSkill, UniversalFallback
+from ovos_workshop.skills.base import BaseSkill
+from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
+from ovos_workshop.skills.common_query_skill import CommonQuerySkill
+from ovos_workshop.skills.fallback import FallbackSkill
+from ovos_workshop.skills.mycroft_skill import MycroftSkill
+from ovos_workshop.skills.ovos import OVOSSkill, OVOSFallbackSkill
+
+SKILL_BASE_CLASSES = [
+    BaseSkill, MycroftSkill, OVOSSkill, OVOSFallbackSkill,
+    OVOSCommonPlaybackSkill, OVOSFallbackSkill, CommonQuerySkill, ActiveSkill,
+    FallbackSkill, UniversalSkill, UniversalFallback
+]
+
+SKILL_MAIN_MODULE = '__init__.py'
+
+
+def get_skill_directories(conf=None):
+    """ returns list of skill directories ordered by expected loading order
+
+    This corresponds to:
+    - XDG_DATA_DIRS
+    - user defined extra directories
+
+    Each directory contains individual skill folders to be loaded
+
+    If a skill exists in more than one directory (same folder name) previous instances will be ignored
+        ie. directories at the end of the list have priority over earlier directories
+
+    NOTE: empty folders are interpreted as disabled skills
+
+    new directories can be defined in mycroft.conf by specifying a full path
+    each extra directory is expected to contain individual skill folders to be loaded
+
+    the xdg folder name can also be changed, it defaults to "skills"
+        eg. ~/.local/share/mycroft/FOLDER_NAME
+
+    {
+        "skills": {
+            "directory": "skills",
+            "extra_directories": ["path/to/extra/dir/to/scan/for/skills"]
+        }
+    }
+
+    Args:
+        conf (dict): mycroft.conf dict, will be loaded automatically if None
+    """
+    # the contents of each skills directory must be individual skill folders
+    # we are still dependent on the mycroft-core structure of skill_id/__init__.py
+
+    conf = conf or Configuration()
+    folder = conf["skills"].get("directory")
+
+    # load all valid XDG paths
+    # NOTE: skills are actually code, but treated as user data!
+    # they should be considered applets rather than full applications
+    skill_locations = list(reversed(
+        [os.path.join(p, folder) for p in get_xdg_data_dirs()]
+    ))
+
+    # load additional explicitly configured directories
+    conf = conf.get("skills") or {}
+    # extra_directories is a list of directories containing skill subdirectories
+    # NOT a list of individual skill folders
+    skill_locations += conf.get("extra_directories") or []
+    return skill_locations
+
+
+def get_default_skills_directory():
+    """ return default directory to scan for skills
+
+    data_dir is always XDG_DATA_DIR
+    If xdg is disabled then data_dir by default corresponds to /opt/mycroft
+
+    users can define the data directory in mycroft.conf
+    the skills folder name (relative to data_dir) can also be defined there
+
+    NOTE: folder name also impacts all XDG skill directories!
+
+    {
+        "skills": {
+            "directory_override": "/opt/mycroft/hardcoded_path/skills"
+        }
+    }
+
+    Args:
+        conf (dict): mycroft.conf dict, will be loaded automatically if None
+    """
+    folder = Configuration()["skills"].get("directory")
+    skills_folder = os.path.join(get_xdg_data_save_path(), folder)
+    # create folder if needed
+    makedirs(skills_folder, exist_ok=True)
+    return path.expanduser(skills_folder)
+
+
+def remove_submodule_refs(module_name):
+    """Ensure submodules are reloaded by removing the refs from sys.modules.
+
+    Python import system puts a reference for each module in the sys.modules
+    dictionary to bypass loading if a module is already in memory. To make
+    sure skills are completely reloaded these references are deleted.
+
+    Args:
+        module_name: name of skill module.
+    """
+    submodules = []
+    LOG.debug(f'Skill module: {module_name}')
+    # Collect found submodules
+    for m in sys.modules:
+        if m.startswith(module_name + '.'):
+            submodules.append(m)
+    # Remove all references them to in sys.modules
+    for m in submodules:
+        LOG.debug(f'Removing sys.modules ref for {m}')
+        del sys.modules[m]
+
+
+def load_skill_module(path, skill_id):
+    """Load a skill module
+
+    This function handles the differences between python 3.4 and 3.5+ as well
+    as makes sure the module is inserted into the sys.modules dict.
+
+    Args:
+        path: Path to the skill main file (__init__.py)
+        skill_id: skill_id used as skill identifier in the module list
+    """
+    module_name = skill_id.replace('.', '_')
+
+    remove_submodule_refs(module_name)
+
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _bad_mod_times(mod_times):
+    """Return all entries with modification time in the future.
+
+    Args:
+        mod_times (dict): dict mapping file paths to modification times.
+
+    Returns:
+        List of files with bad modification times.
+    """
+    current_time = time()
+    return [path for path in mod_times if mod_times[path] > current_time]
+
+
+def _get_last_modified_time(path):
+    """Get the last modified date of the most recently updated file in a path.
+
+    Exclude compiled python files, hidden directories and the settings.json
+    file.
+
+    Args:
+        path: skill directory to check
+
+    Returns:
+        int: time of last change
+    """
+    all_files = []
+    for root_dir, dirs, files in os.walk(path):
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        for f in files:
+            ignore_file = (
+                    f.endswith('.pyc') or
+                    f == 'settings.json' or
+                    f.startswith('.') or
+                    f.endswith('.qmlc')
+            )
+            if not ignore_file:
+                all_files.append(os.path.join(root_dir, f))
+
+    # check files of interest in the skill root directory
+    mod_times = {f: os.path.getmtime(f) for f in all_files}
+    # Ensure modification times are valid
+    bad_times = _bad_mod_times(mod_times)
+    if bad_times:
+        raise OSError(f'{bad_times} had bad modification times')
+    if all_files:
+        return max(os.path.getmtime(f) for f in all_files)
+    else:
+        return 0
+
+
+def get_skill_class(skill_module):
+    """Find MycroftSkill based class in skill module.
+
+    Arguments:
+        skill_module (module): module to search for Skill class
+
+    Returns:
+        (MycroftSkill): Found subclass of MycroftSkill or None.
+    """
+    if callable(skill_module):
+        # it's a skill plugin
+        # either a func that returns the skill or the skill class itself
+        return skill_module
+
+    candidates = []
+    for name, obj in skill_module.__dict__.items():
+        if isclass(obj):
+            if any(issubclass(obj, c) for c in SKILL_BASE_CLASSES) and \
+                    not any(obj is c for c in SKILL_BASE_CLASSES):
+                candidates.append(obj)
+
+    for candidate in list(candidates):
+        others = [clazz for clazz in candidates if clazz != candidate]
+        # if we found a subclass of this candidate, it is not the final skill
+        if any(issubclass(clazz, candidate) for clazz in others):
+            candidates.remove(candidate)
+
+    if candidates:
+        if len(candidates) > 1:
+            LOG.warning(f"Multiple skills found in a single file!\n"
+                        f"{candidates}")
+        LOG.debug(f"Loading skill class: {candidates[0]}")
+        return candidates[0]
+    return None
+
+
+def get_create_skill_function(skill_module):
+    """Find create_skill function in skill module.
+
+    Arguments:
+        skill_module (module): module to search for create_skill function
+
+    Returns:
+        (function): Found create_skill function or None.
+    """
+    if hasattr(skill_module, "create_skill") and \
+            callable(skill_module.create_skill):
+        return skill_module.create_skill
+    return None
+
+
+class SkillLoader:
+    def __init__(self, bus, skill_directory=None):
+        self.bus = bus
+        self._skill_directory = skill_directory
+        self._skill_id = None
+        self._skill_class = None
+        self._loaded = None
+        self.load_attempted = False
+        self.last_modified = 0
+        self.last_loaded = 0
+        self.instance: BaseSkill = None
+        self.active = True
+        self._watchdog = None
+        self.config = Configuration()
+
+        self.modtime_error_log_written = False
+        self.skill_module = None
+
+    @property
+    def loaded(self):
+        return self._loaded  # or self.instance is None
+
+    @loaded.setter
+    def loaded(self, val):
+        self._loaded = val
+
+    @property
+    def skill_directory(self):
+        skill_dir = self._skill_directory
+        if self.instance and not skill_dir:
+            skill_dir = self.instance.root_dir
+        return skill_dir
+
+    @skill_directory.setter
+    def skill_directory(self, val):
+        self._skill_directory = val
+
+    @property
+    def skill_id(self):
+        skill_id = self._skill_id
+        if self.instance and not skill_id:
+            skill_id = self.instance.skill_id
+        if self.skill_directory and not skill_id:
+            skill_id = os.path.basename(self.skill_directory)
+        return skill_id
+
+    @skill_id.setter
+    def skill_id(self, val):
+        self._skill_id = val
+
+    @property
+    def skill_class(self):
+        skill_class = self._skill_class
+        if self.instance and not skill_class:
+            skill_class = self.instance.__class__
+        if self.skill_module and not skill_class:
+            skill_class = get_skill_class(self.skill_module)
+        return skill_class
+
+    @skill_class.setter
+    def skill_class(self, val):
+        self._skill_class = val
+
+    @property
+    def runtime_requirements(self):
+        if not self.skill_class:
+            return RuntimeRequirements()
+        return self.skill_class.runtime_requirements
+
+    @property
+    def is_blacklisted(self):
+        """Boolean value representing whether or not a skill is blacklisted."""
+        blacklist = self.config['skills'].get('blacklisted_skills') or []
+        if self.skill_id in blacklist:
+            return True
+        else:
+            return False
+
+    @property
+    def reload_allowed(self):
+        return self.active and (self.instance is None or self.instance.reload_skill)
+
+    def reload_needed(self):
+        """DEPRECATED: backwards compatibility only
+
+        this is now event based and always returns False after initial load
+        """
+        return self.instance is None
+
+    def reload(self):
+        LOG.info(f'ATTEMPTING TO RELOAD SKILL: {self.skill_id}')
+        if self.instance:
+            if not self.instance.reload_skill:
+                LOG.info("skill does not allow reloading!")
+                return False  # not allowed
+            self._unload()
+        return self._load()
+
+    def load(self):
+        LOG.info(f'ATTEMPTING TO LOAD SKILL: {self.skill_id}')
+        return self._load()
+
+    def _unload(self):
+        """Remove listeners and stop threads before loading"""
+        if self._watchdog:
+            self._watchdog.shutdown()
+            self._watchdog = None
+
+        self._execute_instance_shutdown()
+        if self.config.get("debug", False):
+            self._garbage_collect()
+        self._emit_skill_shutdown_event()
+
+    def unload(self):
+        if self.instance:
+            self._execute_instance_shutdown()
+
+    def activate(self):
+        self.active = True
+        self.load()
+
+    def deactivate(self):
+        self.active = False
+        self.unload()
+
+    def _execute_instance_shutdown(self):
+        """Call the shutdown method of the skill being reloaded."""
+        try:
+            self.instance.default_shutdown()
+        except Exception:
+            LOG.exception(f'An error occurred while shutting down {self.skill_id}')
+        else:
+            LOG.info(f'Skill {self.skill_id} shut down successfully')
+        del self.instance
+        self.instance = None
+
+    def _garbage_collect(self):
+        """Invoke Python garbage collector to remove false references"""
+        gc.collect()
+        # Remove two local references that are known
+        refs = sys.getrefcount(self.instance) - 2
+        if refs > 0:
+            LOG.warning(
+                f"After shutdown of {self.skill_id} there are still {refs} references "
+                "remaining. The skill won't be cleaned from memory."
+            )
+
+    def _emit_skill_shutdown_event(self):
+        message = Message("mycroft.skills.shutdown",
+                          {"path": self.skill_directory, "id": self.skill_id})
+        self.bus.emit(message)
+
+    def _load(self):
+        self._prepare_for_load()
+        if self.is_blacklisted:
+            self._skip_load()
+        else:
+            self.skill_module = self._load_skill_source()
+            self.loaded = self._create_skill_instance()
+
+        self.last_loaded = time()
+        self._communicate_load_status()
+        self._start_filewatcher()
+        return self.loaded
+
+    def _start_filewatcher(self):
+        if not self._watchdog:
+            self._watchdog = FileWatcher([self.skill_directory],
+                                         callback=self._handle_filechange,
+                                         recursive=True)
+
+    def _handle_filechange(self):
+        LOG.info("Skill change detected!")
+
+        try:
+            if self.reload_allowed:
+                self.reload()
+        except Exception:
+            LOG.exception(f'Unhandled exception occurred while reloading {self.skill_directory}')
+
+        # NOTE: below could be removed, but is kept for api backwards compatibility
+        # users of SkillLoader will still have all properties properly updated
+
+        # TODO on ntp sync last_modified needs to be updated
+        try:
+            self.last_modified = _get_last_modified_time(self.skill_directory)
+        except OSError as err:
+            self.last_modified = self.last_loaded
+            if not self.modtime_error_log_written:
+                self.modtime_error_log_written = True
+                LOG.error(f'Failed to get last_modification time ({err})')
+        else:
+            self.modtime_error_log_written = False
+
+    def _prepare_for_load(self):
+        self.load_attempted = True
+        self.instance = None
+
+    def _skip_load(self):
+        LOG.info(f'Skill {self.skill_id} is blacklisted - it will not be loaded')
+
+    def _load_skill_source(self):
+        """Use Python's import library to load a skill's source code."""
+        main_file_path = os.path.join(self.skill_directory, SKILL_MAIN_MODULE)
+        skill_module = None
+        if not os.path.exists(main_file_path):
+            LOG.error(f'Failed to load {self.skill_id} due to a missing file.')
+        else:
+            try:
+                skill_module = load_skill_module(main_file_path, self.skill_id)
+            except Exception as e:
+                LOG.exception(f'Failed to load skill: {self.skill_id} ({e})')
+        return skill_module
+
+    def _create_skill_instance(self, skill_module=None):
+        """create the skill object.
+
+        Arguments:
+            skill_module (module): Module to load from
+
+        Returns:
+            (bool): True if skill was loaded successfully.
+        """
+        skill_module = skill_module or self.skill_module
+        try:
+            skill_creator = get_create_skill_function(skill_module) or \
+                            self.skill_class
+
+            # create the skill
+            # if the signature supports skill_id and bus pass them
+            # to fully initialize the skill in 1 go
+            try:
+                # many skills do not expose this, if they don't allow bus/skill_id kwargs
+                # in __init__ we need to manually call _startup
+                self.instance = skill_creator(bus=self.bus,
+                                              skill_id=self.skill_id)
+                # skills will have bus and skill_id available as soon as they call super()
+            except:
+                self.instance = skill_creator()
+
+            if hasattr(self.instance, "is_fully_initialized"):
+                LOG.warning(f"Deprecated skill signature! Skill class should be"
+                            f" imported from `ovos_workshop.skills`")
+                is_initialized = self.instance.is_fully_initialized
+            else:
+                is_initialized = self.instance._is_fully_initialized
+            if not is_initialized:
+                # finish initialization of skill class
+                self.instance._startup(self.bus, self.skill_id)
+        except Exception as e:
+            LOG.exception(f'Skill __init__ failed with {e}')
+            self.instance = None
+
+        return self.instance is not None
+
+    def _communicate_load_status(self):
+        if self.loaded:
+            message = Message('mycroft.skills.loaded',
+                              {"path": self.skill_directory,
+                               "id": self.skill_id,
+                               "name": self.instance.name,
+                               "modified": self.last_modified})
+            self.bus.emit(message)
+            LOG.info(f'Skill {self.skill_id} loaded successfully')
+        else:
+            message = Message('mycroft.skills.loading_failure',
+                              {"path": self.skill_directory, "id": self.skill_id})
+            self.bus.emit(message)
+            if not self.is_blacklisted:
+                LOG.error(f'Skill {self.skill_id} failed to load')
+            else:
+                LOG.info(f'Skill {self.skill_id} not loaded')
+
+
+class PluginSkillLoader(SkillLoader):
+    def __init__(self, bus, skill_id):
+        super().__init__(bus)
+        self._skill_id = skill_id
+
+    def reload_needed(self):
+        return False
+
+    def load(self, skill_class):
+        LOG.info('ATTEMPTING TO LOAD PLUGIN SKILL: ' + self.skill_id)
+        self._skill_class = skill_class
+        self._prepare_for_load()
+        if self.is_blacklisted:
+            self._skip_load()
+        else:
+            self.loaded = self._create_skill_instance()
+
+        self.last_loaded = time()
+        self._communicate_load_status()
+        return self.loaded
+
+
+def launch_plugin_skill(skill_id):
+    # TODO - cli entrypoint
+    bus = MessageBusClient()
+    bus.run_in_thread()
+    plugins = find_skill_plugins()
+    if skill_id not in plugins:
+        raise ValueError(f"unknown skill_id: {skill_id}")
+    skill_plugin = plugins[skill_id]
+    skill_loader = PluginSkillLoader(bus, skill_id)
+    try:
+        skill_loader.load(skill_plugin)
+        wait_for_exit_signal()
+    except KeyboardInterrupt:
+        skill_loader.deactivate()
+    except Exception:
+        LOG.exception(f'Load of skill {skill_id} failed!')
+
+
+def launch_standalone_skill(skill_directory):
+    # TODO - cli entrypoint
+    bus = MessageBusClient()
+    bus.run_in_thread()
+    skill_loader = SkillLoader(bus, skill_directory)
+    try:
+        skill_loader.load()
+        wait_for_exit_signal()
+    except KeyboardInterrupt:
+        skill_loader.deactivate()
+    except Exception:
+        LOG.exception(f'Load of skill {skill_directory} failed!')

--- a/ovos_workshop/skill_launcher.py
+++ b/ovos_workshop/skill_launcher.py
@@ -155,56 +155,6 @@ def load_skill_module(path, skill_id):
     return mod
 
 
-def _bad_mod_times(mod_times):
-    """Return all entries with modification time in the future.
-
-    Args:
-        mod_times (dict): dict mapping file paths to modification times.
-
-    Returns:
-        List of files with bad modification times.
-    """
-    current_time = time()
-    return [path for path in mod_times if mod_times[path] > current_time]
-
-
-def _get_last_modified_time(path):
-    """Get the last modified date of the most recently updated file in a path.
-
-    Exclude compiled python files, hidden directories and the settings.json
-    file.
-
-    Args:
-        path: skill directory to check
-
-    Returns:
-        int: time of last change
-    """
-    all_files = []
-    for root_dir, dirs, files in os.walk(path):
-        dirs[:] = [d for d in dirs if not d.startswith('.')]
-        for f in files:
-            ignore_file = (
-                    f.endswith('.pyc') or
-                    f == 'settings.json' or
-                    f.startswith('.') or
-                    f.endswith('.qmlc')
-            )
-            if not ignore_file:
-                all_files.append(os.path.join(root_dir, f))
-
-    # check files of interest in the skill root directory
-    mod_times = {f: os.path.getmtime(f) for f in all_files}
-    # Ensure modification times are valid
-    bad_times = _bad_mod_times(mod_times)
-    if bad_times:
-        raise OSError(f'{bad_times} had bad modification times')
-    if all_files:
-        return max(os.path.getmtime(f) for f in all_files)
-    else:
-        return 0
-
-
 def get_skill_class(skill_module):
     """Find MycroftSkill based class in skill module.
 

--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -28,8 +28,8 @@ from typing import List
 from json_database import JsonStorage
 from lingua_franca.format import pronounce_number, join_list
 from lingua_franca.parse import yes_or_no, extract_number
-from ovos_bus_client.message import Message, dig_for_message
 from ovos_backend_client.api import EmailApi, MetricsApi
+from ovos_bus_client.message import Message, dig_for_message
 from ovos_config.config import Configuration
 from ovos_config.locations import get_xdg_config_save_path
 from ovos_utils import camel_case_split
@@ -165,6 +165,7 @@ class BaseSkill:
                  gui=None, enable_settings_manager=True,
                  skill_id=""):
 
+        self.log = LOG  # a dedicated namespace will be assigned in _startup
         self._enable_settings_manager = enable_settings_manager
         self._init_event = Event()
         self.name = name or self.__class__.__name__
@@ -272,8 +273,8 @@ class BaseSkill:
 
     @voc_match_cache.setter
     def voc_match_cache(self, val):
-        LOG.warning("self._voc_cache should not be modified externally. This"
-                    "functionality will be deprecated in a future release")
+        self.log.warning("self._voc_cache should not be modified externally. This"
+                         "functionality will be deprecated in a future release")
         if isinstance(val, dict):
             self._voc_cache = val
 
@@ -299,7 +300,7 @@ class BaseSkill:
         """Determine if its the very first time a skill is run."""
         first_run = self.settings.get("__mycroft_skill_firstrun", True)
         if first_run:
-            LOG.info("First run of " + self.skill_id)
+            self.log.info("First run of " + self.skill_id)
             self._handle_first_run()
             self.settings["__mycroft_skill_firstrun"] = False
             self.settings.store()
@@ -317,7 +318,7 @@ class BaseSkill:
                 but skill loader can override this
         """
         if self._is_fully_initialized:
-            LOG.warning(f"Tried to initialize {self.skill_id} multiple times, ignoring")
+            self.log.warning(f"Tried to initialize {self.skill_id} multiple times, ignoring")
             return
 
         # NOTE: this method is called by SkillLoader
@@ -348,7 +349,7 @@ class BaseSkill:
             self._check_for_first_run()
             self._init_event.set()
         except Exception as e:
-            LOG.exception('Skill initialization failed')
+            self.log.exception('Skill initialization failed')
             # If an exception occurs, attempt to clean up the skill
             try:
                 self.default_shutdown()
@@ -358,17 +359,14 @@ class BaseSkill:
 
     def _init_settings(self):
         """Setup skill settings."""
-        LOG.debug(f"initializing skill settings for {self.skill_id}")
+        self.log.debug(f"initializing skill settings for {self.skill_id}")
 
         # NOTE: lock is disabled due to usage of deepcopy and to allow json serialization
         self._settings = JsonStorage(self._settings_path, disable_lock=True)
         if self._initial_settings and not self._is_fully_initialized:
-            # TODO make a debug log in next version
-            LOG.warning("Copying default settings values defined in __init__ \n"
-                        "Please move code from __init__() to initialize() "
-                        "if you did not expect to see this message")
-            LOG.warning(f"to correct this add kwargs __init__(bus=None, skill_id='') "
-                        f"to skill class {self.__class__.__name__}")
+            self.log.warning("Copying default settings values defined in __init__ \n"
+                             f"to correct this add kwargs __init__(bus=None, skill_id='') "
+                             f"to skill class {self.__class__.__name__}")
             for k, v in self._initial_settings.items():
                 if k not in self._settings:
                     self._settings[k] = v
@@ -434,10 +432,11 @@ class BaseSkill:
         if self._settings is not None:
             return self._settings
         else:
-            LOG.error('Skill not fully initialized. '
-                      'Only default values can be set, no settings can be read or changed.')
-            LOG.warning(f"to correct this add kwargs __init__(bus=None, skill_id='') "
-                        f"to skill class {self.__class__.__name__}")
+            self.log.warning('Skill not fully initialized. '
+                             'Only default values can be set, no settings can be read or changed.'
+                             f"to correct this add kwargs __init__(bus=None, skill_id='') "
+                             f"to skill class {self.__class__.__name__}")
+            self.log.error(simple_trace(traceback.format_stack()))
             return self._initial_settings
 
     # not a property in mycroft-core
@@ -462,10 +461,10 @@ class BaseSkill:
         if self._enclosure:
             return self._enclosure
         else:
-            LOG.error('Skill not fully initialized.')
-            LOG.warning(f"to correct this add kwargs __init__(bus=None, skill_id='') "
-                        f"to skill class {self.__class__.__name__}")
-            LOG.error(simple_trace(traceback.format_stack()))
+            self.log.warning('Skill not fully initialized.'
+                             f"to correct this add kwargs __init__(bus=None, skill_id='') "
+                             f"to skill class {self.__class__.__name__}")
+            self.log.error(simple_trace(traceback.format_stack()))
             raise Exception('Accessed MycroftSkill.enclosure in __init__')
 
     # not a property in mycroft-core
@@ -480,10 +479,10 @@ class BaseSkill:
         if self._file_system:
             return self._file_system
         else:
-            LOG.error('Skill not fully initialized.')
-            LOG.warning(f"to correct this add kwargs __init__(bus=None, skill_id='') "
-                        f"to skill class {self.__class__.__name__}")
-            LOG.error(simple_trace(traceback.format_stack()))
+            self.log.warning('Skill not fully initialized.'
+                             f"to correct this add kwargs __init__(bus=None, skill_id='') "
+                             f"to skill class {self.__class__.__name__}")
+            self.log.error(simple_trace(traceback.format_stack()))
             raise Exception('Accessed MycroftSkill.file_system in __init__')
 
     @file_system.setter
@@ -497,10 +496,10 @@ class BaseSkill:
         if self._bus:
             return self._bus
         else:
-            LOG.error('Skill not fully initialized.')
-            LOG.warning(f"to correct this add kwargs __init__(bus=None, skill_id='') "
-                        f"to skill class {self.__class__.__name__}")
-            LOG.error(simple_trace(traceback.format_stack()))
+            self.log.warning('Skill not fully initialized.'
+                             f"to correct this add kwargs __init__(bus=None, skill_id='') "
+                             f"to skill class {self.__class__.__name__}")
+            self.log.error(simple_trace(traceback.format_stack()))
             raise Exception('Accessed MycroftSkill.bus in __init__')
 
     @bus.setter
@@ -679,7 +678,7 @@ class BaseSkill:
         for key in self.public_api:
             if ('type' in self.public_api[key] and
                     'func' in self.public_api[key]):
-                LOG.debug(f"Adding api method: {self.public_api[key]['type']}")
+                self.log.debug(f"Adding api method: {self.public_api[key]['type']}")
 
                 # remove the function member since it shouldn't be
                 # reused and can't be sent over the messagebus
@@ -732,7 +731,7 @@ class BaseSkill:
         """
         remote_settings = message.data.get(self.skill_id)
         if remote_settings is not None:
-            LOG.info('Updating settings for skill ' + self.skill_id)
+            self.log.info('Updating settings for skill ' + self.skill_id)
             self.settings.update(**remote_settings)
             self.settings.store()
             if self.settings_change_callback is not None:
@@ -1203,7 +1202,7 @@ class BaseSkill:
             if Configuration().get('opt_in', False):
                 MetricsApi().report_metric(name, data)
         except Exception as e:
-            LOG.error(f'Metric couldn\'t be uploaded, due to a network error ({e})')
+            self.log.error(f'Metric couldn\'t be uploaded, due to a network error ({e})')
 
     def send_email(self, title, body):
         """Send an email to the registered user's email.
@@ -1331,7 +1330,7 @@ class BaseSkill:
         speech = get_dialog('skill.error', self.lang, msg_data)
         if speak_errors:
             self.speak(speech)
-        LOG.exception(error)
+        self.log.exception(error)
         # append exception information in message
         skill_data['exception'] = repr(error)
         if handler_info:
@@ -1359,7 +1358,7 @@ class BaseSkill:
 
         def on_error(error, message):
             if isinstance(error, AbortEvent):
-                LOG.info("Skill execution aborted")
+                self.log.info("Skill execution aborted")
                 self._on_event_end(message, handler_info, skill_data)
                 return
             self._on_event_error(error, message, handler_info, skill_data, speak_errors)
@@ -1517,7 +1516,7 @@ class BaseSkill:
                 bool: True if disabled, False if it wasn't registered
         """
         if intent_name in self.intent_service:
-            LOG.info('Disabling intent ' + intent_name)
+            self.log.info('Disabling intent ' + intent_name)
             name = f'{self.skill_id}:{intent_name}'
             self.intent_service.detach_intent(name)
 
@@ -1527,7 +1526,7 @@ class BaseSkill:
                 self.intent_service.detach_intent(lang_intent_name)
             return True
         else:
-            LOG.error(f'Could not disable {intent_name}, it hasn\'t been registered.')
+            self.log.error(f'Could not disable {intent_name}, it hasn\'t been registered.')
             return False
 
     def enable_intent(self, intent_name):
@@ -1546,10 +1545,10 @@ class BaseSkill:
             else:
                 intent.name = intent_name
                 self.register_intent(intent, None)
-            LOG.debug(f'Enabling intent {intent_name}')
+            self.log.debug(f'Enabling intent {intent_name}')
             return True
         else:
-            LOG.error(f'Could not enable {intent_name}, it hasn\'t been registered.')
+            self.log.error(f'Could not enable {intent_name}, it hasn\'t been registered.')
             return False
 
     def set_context(self, context, word='', origin=''):
@@ -1758,8 +1757,7 @@ class BaseSkill:
                                             {"by": "skill:" + self.skill_id},
                                             {"skill_id": self.skill_id}))
         except Exception as e:
-            LOG.exception(e)
-            LOG.error(f'Failed to stop skill: {self.skill_id}')
+            self.log.exception(f'Failed to stop skill: {self.skill_id}')
 
     def stop(self):
         """Optional method implemented by subclass."""
@@ -1801,12 +1799,12 @@ class BaseSkill:
         try:
             self.stop()
         except Exception:
-            LOG.error(f'Failed to stop skill: {self.skill_id}', exc_info=True)
+            self.log.error(f'Failed to stop skill: {self.skill_id}', exc_info=True)
 
         try:
             self.shutdown()
         except Exception as e:
-            LOG.error(f'Skill specific shutdown function encountered an error: {e}')
+            self.log.error(f'Skill specific shutdown function encountered an error: {e}')
 
         self.bus.emit(
             Message('detach_skill', {'skill_id': str(self.skill_id) + ':'},

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,10 @@ setup(
     author='jarbasAi',
     author_email='jarbasai@mailfence.com',
     include_package_data=True,
-    description='frameworks, templates and patches for the mycroft universe'
+    description='frameworks, templates and patches for the mycroft universe',
+    entry_points={
+        'console_scripts': [
+            'ovos-skill-launcher=ovos_workshop.skill_launcher:_launch_script'
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     author='jarbasAi',
     author_email='jarbasai@mailfence.com',
     include_package_data=True,
-    description='frameworks, templates and patches for the mycroft universe',
+    description='frameworks, templates and patches for the OpenVoiceOS universe',
     entry_points={
         'console_scripts': [
             'ovos-skill-launcher=ovos_workshop.skill_launcher:_launch_script'


### PR DESCRIPTION
move some logic out of core, add helpers to launch skills standalone

if skills provide skill_id and bus in their kwargs / create_skill method they will initialize like regular python objects as soon as possible, this removes the issues around skill_id not being available before initialize

new cli entrypoints allow running skills fully standalone, eg, in docker

[companion PR in core](https://github.com/OpenVoiceOS/ovos-core/pull/306) imports from here and deprecates `mycroft.skills.skill_loader.py`

`USAGE: ovos-skill-launcher {skill_id} [path/to/my/skill_id]`

supports passing a full path to a local skill to help in development