### PR TITLE
refactor/skill_init_wizardry

### DIFF
--- a/ovos_workshop/skill_launcher.py
+++ b/ovos_workshop/skill_launcher.py
@@ -409,10 +409,10 @@ class SkillLoader:
         """
         skill_module = skill_module or self.skill_module
         try:
-
             # in skill classes __new__ should fully create the skill object
             try:
-                self.instance = self.skill_class(bus=self.bus, skill_id=self.skill_id)
+                skill_class = get_skill_class(skill_module)
+                self.instance = skill_class(bus=self.bus, skill_id=self.skill_id)
             except:  # guess it wasnt subclassing from ovos_workshop (fail here ?)
 
                 # attempt to use old style create_skill function entrypoint

--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -191,7 +191,7 @@ class BaseSkill:
         # skill loader was not used to create skill object, we are missing the kwargs
         # skill wont be fully inited, please move logic to initialize
         LOG.warning(f"{cls.__name__} not fully inited, self.bus and self.skill_id will only be available in self.initialize")
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls)
 
     def __init__(self, name=None, bus=None, resources_dir=None,
                  settings: JsonStorage = None,

--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -170,8 +170,23 @@ class BaseSkill:
     """Base class for mycroft skills providing common behaviour and parameters
     to all Skill implementations. This base class does not require `mycroft` to be importable
 
-    Args:
-        name (str): skill name
+    skill_launcher.py used to be skill_loader-py in mycroft-core
+
+    for launching skills one can use skill_launcher.py to run them standalone (eg, docker),
+    but the main objective is to make skills work more like proper python objects and allow usage of the class directly
+
+    the considerations are:
+
+    - most skills in the wild dont expose kwargs, so dont accept skill_id or bus
+    - most skills expect a loader class to set up the bus and skill_id after object creation
+    - skills can not do pythonic things in init, instead of doing things after super() devs are expected to use initialize() which is a mycroft invention and non-standard
+    - main concern is that anything depending on self.skill_id being set can not be used in init method (eg. self.settings and self.file_system)
+    - __new__ uncouples the skill init from a helper class, making skills work like regular python objects
+    - the magic in `__new__` is just so we dont break everything in the wild, since we cant start requiring skill_id and bus args
+
+    KwArgs:
+        name (str): skill name - DEPRECATED
+        skill_id (str): unique skill identifier
         bus (MycroftWebsocketClient): Optional bus connection
     """
 

--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -175,6 +175,24 @@ class BaseSkill:
         bus (MycroftWebsocketClient): Optional bus connection
     """
 
+    def __new__(cls, *args, **kwargs):
+        if "skill_id" in kwargs and "bus" in kwargs:
+            skill_id = kwargs["skill_id"]
+            bus = kwargs["bus"]
+            try:
+                # skill follows latest best practices, accepts kwargs and does its own init
+                return super().__new__(cls, skill_id=skill_id, bus=bus)
+            except:
+                # skill did not update its init method, let's do some magic to init it manually
+                skill = super().__new__(cls, *args, **kwargs)
+                skill._startup(bus, skill_id)
+                return skill
+
+        # skill loader was not used to create skill object, we are missing the kwargs
+        # skill wont be fully inited, please move logic to initialize
+        LOG.warning(f"{cls.__name__} not fully inited, self.bus and self.skill_id will only be available in self.initialize")
+        return super().__new__(cls, *args, **kwargs)
+
     def __init__(self, name=None, bus=None, resources_dir=None,
                  settings: JsonStorage = None,
                  gui=None, enable_settings_manager=True,


### PR DESCRIPTION
follow up to #65 

do not require skills in the wild to be updated to accept `**kwarg`s in their `__init__` method in order to be fully initialized

this allows all skills to use `self.skill_id` and `self.bus` after calling `super()` in `__init__` method

related discussion https://github.com/MycroftAI/mycroft-core/pull/2855