### PR TITLE
fix/activate_plugin_skills

### DIFF
--- a/ovos_workshop/skill_launcher.py
+++ b/ovos_workshop/skill_launcher.py
@@ -474,6 +474,10 @@ class PluginSkillLoader(SkillLoader):
         self._communicate_load_status()
         return self.loaded
 
+    def activate(self):
+        self.active = True
+        self.load(self._skill_class)
+
 
 class SkillContainer:
     def __init__(self, skill_id, skill_directory=None, bus=None):


### PR DESCRIPTION
```
 14:14:45.286 - skills - mycroft.skills.skill_manager:activate_skill:754 - ERROR - Couldn't activate skill
Traceback (most recent call last):
  File "/home/ovos/.local/lib/python3.10/site-packages/mycroft/skills/skill_manager.py", line 752, in activate_skill
    skill_loader.activate()
  File "/home/ovos/.local/lib/python3.10/site-packages/mycroft/skills/skill_loader.py", line 419, in activate
    self.load()
TypeError: PluginSkillLoader.load() missing 1 required positional argument: 'skill_class'

```