### PR TITLE
Unit tests and improvements to settings change callback

### DIFF
--- a/ovos_workshop/skills/base.py
+++ b/ovos_workshop/skills/base.py
@@ -679,6 +679,9 @@ class BaseSkill:
         changes if a backend is configured.
         @param path: Modified file path
         """
+        if path != self._settings.path:
+            LOG.debug(f"Ignoring non-settings change")
+            return
         if self._settings:
             with self._settings_lock:
                 self._settings.reload()


### PR DESCRIPTION
Refactor `_handle_settings_file_change` to ignore non-settings file changes
Add unit tests for settings filewatcher and file change callback
Potentially closes #91