### PR TITLE
Update OVOSAbstractApplication and unit tests

### DIFF
--- a/ovos_workshop/app.py
+++ b/ovos_workshop/app.py
@@ -14,7 +14,7 @@ class OVOSAbstractApplication(OVOSSkill):
                  resources_dir: Optional[str] = None,
                  lang=None, settings: Optional[dict] = None,
                  gui: Optional[GUIInterface] = None,
-                 enable_settings_manager: bool = False):
+                 enable_settings_manager: bool = False, **kwargs):
         """
         Create an Application. An application is essentially a skill, but
         designed such that it may be run without an intent service.
@@ -28,8 +28,10 @@ class OVOSAbstractApplication(OVOSSkill):
         @param enable_settings_manager: if True, enables a SettingsManager for
             this application to manage default settings and backend sync
         """
-        super().__init__(bus=bus, gui=gui, resources_dir=resources_dir,
-                         enable_settings_manager=enable_settings_manager)
+        super().__init__(skill_id=skill_id, bus=bus, gui=gui,
+                         resources_dir=resources_dir,
+                         enable_settings_manager=enable_settings_manager,
+                         **kwargs)
         self.skill_id = skill_id
         self._dedicated_bus = False
         if bus:


### PR DESCRIPTION
Update OVOSAbstractApplication to pass init kwargs as expected
Update abstract_app tests to account for new application init