### PR TITLE
Minor import and logging updates to troubleshoot logged warnings

### DIFF
--- a/ovos_workshop/skills/common_play.py
+++ b/ovos_workshop/skills/common_play.py
@@ -50,8 +50,8 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
     vocab for starting playback is needed.
     """
 
-    def __init__(self, name=None, bus=None):
-        super().__init__(name, bus)
+    def __init__(self, name=None, bus=None, **kwargs):
+        OVOSSkill.__init__(self, name, bus, **kwargs)
         # NOTE: derived skills will likely want to override this list
         self.supported_media = [MediaType.GENERIC,
                                 MediaType.AUDIO]

--- a/ovos_workshop/skills/common_play.py
+++ b/ovos_workshop/skills/common_play.py
@@ -50,9 +50,7 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
     vocab for starting playback is needed.
     """
 
-    def __init__(self, name=None, bus=None, **kwargs):
-        OVOSSkill.__init__(self, name, bus, **kwargs)
-        # NOTE: derived skills will likely want to override this list
+    def __init__(self, name=None, bus=None, **kwargs):        # NOTE: derived skills will likely want to override this list
         self.supported_media = [MediaType.GENERIC,
                                 MediaType.AUDIO]
         self._search_handlers = []  # added via decorators
@@ -67,6 +65,7 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
         self._playing = Event()
         # TODO replace with new default
         self.skill_icon = "https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/raw/master/ovos_plugin_common_play/ocp/res/ui/images/ocp.png"
+        OVOSSkill.__init__(self, name, bus, **kwargs)
 
     def bind(self, bus):
         """Overrides the normal bind method.

--- a/ovos_workshop/skills/common_play.py
+++ b/ovos_workshop/skills/common_play.py
@@ -50,7 +50,8 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
     vocab for starting playback is needed.
     """
 
-    def __init__(self, name=None, bus=None, **kwargs):        # NOTE: derived skills will likely want to override this list
+    def __init__(self, name=None, bus=None, **kwargs):
+        # NOTE: derived skills will likely want to override this list
         self.supported_media = [MediaType.GENERIC,
                                 MediaType.AUDIO]
         self._search_handlers = []  # added via decorators
@@ -64,7 +65,9 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
         self._stop_event = Event()
         self._playing = Event()
         # TODO replace with new default
-        self.skill_icon = "https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/raw/master/ovos_plugin_common_play/ocp/res/ui/images/ocp.png"
+        self.skill_icon = \
+            "https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/raw/master/" \
+            "ovos_plugin_common_play/ocp/res/ui/images/ocp.png"
         OVOSSkill.__init__(self, name, bus, **kwargs)
 
     def bind(self, bus):

--- a/ovos_workshop/skills/common_query_skill.py
+++ b/ovos_workshop/skills/common_query_skill.py
@@ -16,7 +16,7 @@ from os.path import dirname
 
 from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.log import LOG
-
+from ovos_config.config import Configuration
 from ovos_workshop.skills.ovos import OVOSSkill, is_classic_core
 
 
@@ -57,17 +57,6 @@ class CommonQuerySkill(OVOSSkill):
     """
 
     def __init__(self, name=None, bus=None, **kwargs):
-        noise_words_filepath = f"text/{self.lang}/noise_words.list"
-        default_res = f"{dirname(dirname(__file__))}/res/text/{self.lang}/noise_words.list"
-        noise_words_filename = resolve_resource_file(noise_words_filepath) or \
-                               resolve_resource_file(default_res)
-
-        self._translated_noise_words = {}
-        if noise_words_filename:
-            with open(noise_words_filename) as f:
-                translated_noise_words = f.read().strip()
-            self._translated_noise_words[self.lang] = translated_noise_words.split()
-
         # these should probably be configurable
         self.level_confidence = {
             CQSMatchLevel.EXACT: 0.9,
@@ -75,6 +64,21 @@ class CommonQuerySkill(OVOSSkill):
             CQSMatchLevel.GENERAL: 0.5
         }
         OVOSSkill.__init__(self, name, bus, **kwargs)
+
+        noise_words_filepath = f"text/{self.lang}/noise_words.list"
+        default_res = f"{dirname(dirname(__file__))}/res/text/{self.lang}" \
+                      f"/noise_words.list"
+        noise_words_filename = \
+            resolve_resource_file(noise_words_filepath,
+                                  config=self.config_core) or \
+            resolve_resource_file(default_res, config=self.config_core)
+
+        self._translated_noise_words = {}
+        if noise_words_filename:
+            with open(noise_words_filename) as f:
+                translated_noise_words = f.read().strip()
+            self._translated_noise_words[self.lang] = \
+                translated_noise_words.split()
 
     @property
     def translated_noise_words(self):

--- a/ovos_workshop/skills/common_query_skill.py
+++ b/ovos_workshop/skills/common_query_skill.py
@@ -16,7 +16,6 @@ from os.path import dirname
 
 from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.log import LOG
-from ovos_config.config import Configuration
 from ovos_workshop.skills.ovos import OVOSSkill, is_classic_core
 
 

--- a/ovos_workshop/skills/common_query_skill.py
+++ b/ovos_workshop/skills/common_query_skill.py
@@ -56,8 +56,8 @@ class CommonQuerySkill(OVOSSkill):
     answers from several skills presenting the best one available.
     """
 
-    def __init__(self, name=None, bus=None):
-        super().__init__(name, bus)
+    def __init__(self, name=None, bus=None, **kwargs):
+        OVOSSkill.__init__(self, name, bus, **kwargs)
         noise_words_filepath = f"text/{self.lang}/noise_words.list"
         default_res = f"{dirname(dirname(__file__))}/res/text/{self.lang}/noise_words.list"
         noise_words_filename = resolve_resource_file(noise_words_filepath) or \

--- a/ovos_workshop/skills/common_query_skill.py
+++ b/ovos_workshop/skills/common_query_skill.py
@@ -57,7 +57,6 @@ class CommonQuerySkill(OVOSSkill):
     """
 
     def __init__(self, name=None, bus=None, **kwargs):
-        OVOSSkill.__init__(self, name, bus, **kwargs)
         noise_words_filepath = f"text/{self.lang}/noise_words.list"
         default_res = f"{dirname(dirname(__file__))}/res/text/{self.lang}/noise_words.list"
         noise_words_filename = resolve_resource_file(noise_words_filepath) or \
@@ -75,6 +74,7 @@ class CommonQuerySkill(OVOSSkill):
             CQSMatchLevel.CATEGORY: 0.6,
             CQSMatchLevel.GENERAL: 0.5
         }
+        OVOSSkill.__init__(self, name, bus, **kwargs)
 
     @property
     def translated_noise_words(self):

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -99,8 +99,8 @@ class FallbackSkillV1(_MetaFB, metaclass=_MutableFallback):
     fallback_handlers = {}
     wrapper_map: List[Tuple[callable, callable]] = []  # [(handler, wrapper)]
 
-    def __init__(self, name=None, bus=None, use_settings=True):
-        super().__init__(name, bus, use_settings)
+    def __init__(self, name=None, bus=None, use_settings=True, **kwargs):
+        super().__init__(name, bus, use_settings, **kwargs)
         #  list of fallback handlers registered by this instance
         self.instance_fallback_handlers = []
 
@@ -312,9 +312,9 @@ class FallbackSkillV2(_MetaFB, metaclass=_MutableFallback):
         """
         return FallbackSkillV1.make_intent_failure_handler(bus)
 
-    def __init__(self, bus=None, skill_id=""):
+    def __init__(self, bus=None, skill_id="", **kwargs):
         self._fallback_handlers = []
-        super().__init__(bus=bus, skill_id=skill_id)
+        super().__init__(bus=bus, skill_id=skill_id, **kwargs)
 
     @property
     def priority(self) -> int:

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -103,9 +103,9 @@ class FallbackSkillV1(_MetaFB, metaclass=_MutableFallback):
         #  list of fallback handlers registered by this instance
         self.instance_fallback_handlers = []
 
+        super().__init__(name, bus, use_settings, **kwargs)
         # "skill_id": priority (int)  overrides
         self.fallback_config = self.config_core["skills"].get("fallbacks", {})
-        super().__init__(name, bus, use_settings, **kwargs)
 
     @classmethod
     def make_intent_failure_handler(cls, bus: MessageBusClient):

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -100,12 +100,12 @@ class FallbackSkillV1(_MetaFB, metaclass=_MutableFallback):
     wrapper_map: List[Tuple[callable, callable]] = []  # [(handler, wrapper)]
 
     def __init__(self, name=None, bus=None, use_settings=True, **kwargs):
-        super().__init__(name, bus, use_settings, **kwargs)
         #  list of fallback handlers registered by this instance
         self.instance_fallback_handlers = []
 
         # "skill_id": priority (int)  overrides
         self.fallback_config = self.config_core["skills"].get("fallbacks", {})
+        super().__init__(name, bus, use_settings, **kwargs)
 
     @classmethod
     def make_intent_failure_handler(cls, bus: MessageBusClient):

--- a/ovos_workshop/skills/mycroft_skill.py
+++ b/ovos_workshop/skills/mycroft_skill.py
@@ -96,10 +96,11 @@ class _SkillMetaclass(ABCMeta):
             # accepts kwargs and does its own init
             return super().__call__(skill_id=skill_id, bus=bus, **kwargs)
         except TypeError:
-            LOG.warning("legacy skill signature detected, attempting to init "
-                        "skill manually, self.bus and self.skill_id will only "
-                        "be available in self.initialize.\n__init__ method "
-                        "needs to accept `skill_id` and `bus` to resolve this.")
+            LOG.warning(f"Legacy skill signature detected for {skill_id};"
+                        f" attempting to init skill manually, self.bus and "
+                        f"self.skill_id will only be available in "
+                        f"self.initialize. `__init__` method needs to accept "
+                        f"`skill_id` and `bus` to resolve this.")
 
         # skill did not update its init method, init it manually
         # NOTE: no try/except because all skills must accept this initialization

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -13,7 +13,7 @@ from ovos_utils.skills.settings import PrivateSettings
 from ovos_utils.sound import play_audio
 from ovos_workshop.resource_files import SkillResources
 
-from ovos_workshop.skills.layers import IntentLayers
+from ovos_workshop.decorators.layers import IntentLayers
 from ovos_workshop.skills.mycroft_skill import MycroftSkill, is_classic_core
 
 


### PR DESCRIPTION
Update internal import to avoid deprecation warning
Add `skill_id` to logged warnings to diagnose legacy behavior
Refactors skill base classes for new init and backwards-compat. with `initialize`