### PR TITLE
fix/abstract app init

### DIFF
--- a/ovos_workshop/app.py
+++ b/ovos_workshop/app.py
@@ -28,18 +28,18 @@ class OVOSAbstractApplication(OVOSSkill):
         @param enable_settings_manager: if True, enables a SettingsManager for
             this application to manage default settings and backend sync
         """
-        super().__init__(skill_id=skill_id, bus=bus, gui=gui,
-                         resources_dir=resources_dir,
-                         enable_settings_manager=enable_settings_manager,
-                         **kwargs)
-        self.skill_id = skill_id
         self._dedicated_bus = False
         if bus:
             self._dedicated_bus = False
         else:
             self._dedicated_bus = True
             bus = get_mycroft_bus()
-        self._startup(bus, skill_id)
+
+        super().__init__(skill_id=skill_id, bus=bus, gui=gui,
+                         resources_dir=resources_dir,
+                         enable_settings_manager=enable_settings_manager,
+                         **kwargs)
+
         if settings:
             log_deprecation(f"Settings should be set in {self._settings_path}. "
                             f"Passing `settings` to __init__ is not supported.",

--- a/ovos_workshop/skills/mycroft_skill.py
+++ b/ovos_workshop/skills/mycroft_skill.py
@@ -19,7 +19,7 @@ from os.path import join, exists
 from typing import Optional
 
 from ovos_bus_client import MessageBusClient, Message
-from ovos_utils.log import LOG, log_deprecation
+from ovos_utils.log import LOG, log_deprecation, deprecated
 from ovos_workshop.skills.base import BaseSkill, is_classic_core
 
 
@@ -126,6 +126,7 @@ class MycroftSkill(BaseSkill, metaclass=_SkillMetaclass):
     recommended to implement `OVOSSkill` to properly implement new methods.
     """
 
+    @deprecated("MycroftSkill class has been deprecated, please subclass from OVOSSkill", "0.1.0")
     def __init__(self, name: str = None, bus: MessageBusClient = None,
                  use_settings: bool = True, *args, **kwargs):
         """

--- a/ovos_workshop/skills/mycroft_skill.py
+++ b/ovos_workshop/skills/mycroft_skill.py
@@ -113,10 +113,12 @@ class _SkillMetaclass(ABCMeta):
         if is_classic_core():
             # instance imported from vanilla mycroft
             from mycroft.skills import MycroftSkill as _CoreSkill
-            if issubclass(self.__class__, _CoreSkill):
+            if issubclass(instance.__class__, _CoreSkill):
                 return True
 
-        return super().__instancecheck__(instance)
+        from ovos_workshop.skills.ovos import OVOSSkill
+        return super().__instancecheck__(instance) or \
+            issubclass(instance.__class__, OVOSSkill)
 
 
 class MycroftSkill(BaseSkill, metaclass=_SkillMetaclass):

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -26,7 +26,7 @@ class _OVOSSkillMetaclass(ABCMeta):
         if is_classic_core():
             # instance imported from vanilla mycroft
             from mycroft.skills import MycroftSkill as _CoreSkill
-            if issubclass(self.__class__, _CoreSkill):
+            if issubclass(instance.__class__, _CoreSkill):
                 return True
 
         return super().__instancecheck__(instance) or \

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -30,7 +30,7 @@ class _OVOSSkillMetaclass(ABCMeta):
                 return True
 
         return super().__instancecheck__(instance) or \
-            issubclass(self.__class__, MycroftSkill)
+            issubclass(instance.__class__, MycroftSkill)
 
 
 class OVOSSkill(BaseSkill, metaclass=_OVOSSkillMetaclass):

--- a/test/unittests/skills/test_active.py
+++ b/test/unittests/skills/test_active.py
@@ -11,7 +11,7 @@ class ActiveSkillExample(ActiveSkill):
 
     def make_active(self):
         self.active()
-        ActiveSkill.make_active(self)
+        ActiveSkill.activate(self)
 
 
 class TestActiveSkill(unittest.TestCase):

--- a/test/unittests/test_skill_launcher.py
+++ b/test/unittests/test_skill_launcher.py
@@ -67,14 +67,14 @@ class TestSkillLauncherFunctions(unittest.TestCase):
     def test_get_skill_class(self):
         from ovos_workshop.skill_launcher import get_skill_class, \
             load_skill_module
-        from ovos_workshop.skills.mycroft_skill import _SkillMetaclass
+        from ovos_workshop.skills.ovos import _OVOSSkillMetaclass
         test_path = join(dirname(__file__), "ovos_tskill_abort",
                          "__init__.py")
         skill_id = "test_skill.test"
         module = load_skill_module(test_path, skill_id)
         skill = get_skill_class(module)
         self.assertIsNotNone(skill)
-        self.assertEqual(skill.__class__, _SkillMetaclass, skill.__class__)
+        self.assertEqual(skill.__class__, _OVOSSkillMetaclass, skill.__class__)
 
         # Test invalid request
         with self.assertRaises(ValueError):


### PR DESCRIPTION
skill_id and bus are now handled in super() , the call to self._startup should not be done anymore

makes OVOSSkill a subclass of BaseSkill and marks MycroftSkill for deprecation


the metaclass override of `__call__` is problematic for OVOSAbstractApps such as PHAL*, OCP, Persona and CommonIOT, it is also only there as a compat layer for classic mycroft skills, we avoid the issue by only applying that to the MycroftSkill class itself but not to OVOSSkill  (since it's no longer a subclass of MycroftSkill)

`* PHAL error logs in comments below, fixed by not subclassing anymore from OVOSAbstractApp`