### PR TITLE
feat/extend_ovosskill

### DIFF
--- a/ovos_workshop/skills/auto_translatable.py
+++ b/ovos_workshop/skills/auto_translatable.py
@@ -27,9 +27,6 @@ class UniversalSkill(OVOSSkill):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.lang_detector = OVOSLangDetectionFactory.create()
-        self.translator = OVOSLangTranslationFactory.create()
-
         # the skill internally only works in this language
         self.internal_language = None
         # __tags__ private value will be translated (adapt entities)

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -337,7 +337,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         """ language detector, lazy init on first access"""
         if not self._lang_detector:
             # if it's being used, there is no recovery, do not try: except:
-            self._lang_detector = OVOSLangDetectionFactory.create()
+            self._lang_detector = OVOSLangDetectionFactory.create(self.config_core)
         return self._lang_detector
 
     @lang_detector.setter
@@ -349,7 +349,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         """ language translator, lazy init on first access"""
         if not self._translator:
             # if it's being used, there is no recovery, do not try: except:
-            self._translator = OVOSLangTranslationFactory.create()
+            self._translator = OVOSLangTranslationFactory.create(self.config_core)
         return self._translator
 
     @translator.setter

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -340,6 +340,10 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
             self._lang_detector = OVOSLangDetectionFactory.create()
         return self._lang_detector
 
+    @lang_detector.setter
+    def lang_detector(self, val):
+        self._lang_detector = val
+
     @property
     def translator(self):
         """ language translator, lazy init on first access"""
@@ -347,6 +351,10 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
             # if it's being used, there is no recovery, do not try: except:
             self._translator = OVOSLangTranslationFactory.create()
         return self._translator
+
+    @translator.setter
+    def translator(self, val):
+        self._translator = val
 
     @property
     def settings_path(self) -> str:


### PR DESCRIPTION
extend skill class to include support for language plugins:
- makes it easier to share the underlying object with the solver plugins https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/183
- api compat with NeonSkill class to reduce divergence
- lazy init on first usage, no extra resource usage in existing skills

extend self.activate:
- allow skills to specify how long they want to remain active
- api compat with NeonSkill class to reduce divergence
- TODO - companion PR in core