### PR TITLE
fix/sounds_in_docker

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1596,7 +1596,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         else:
             mtype = "mycroft.audio.queue"
 
-        if not send_binary:
+        if not send_binary or not isfile(filename):
             data = {"uri": filename}
         else:
             with open(filename, "rb") as f:


### PR DESCRIPTION
default sounds only exist in ovos-audio, if running in docker ovos-workshop attempts to read the data from a nonexisting file

just try using self.acknowledge to demonstrate the issue