### PR TITLE
refactor/skill_activation_before_events

### DIFF
--- a/ovos_workshop/skills/common_query_skill.py
+++ b/ovos_workshop/skills/common_query_skill.py
@@ -240,6 +240,7 @@ class CommonQuerySkill(OVOSSkill):
         if message.data["skill_id"] != self.skill_id:
             # Not for this skill!
             return
+        self.activate()
         phrase = message.data["phrase"]
         data = message.data.get("callback_data") or {}
         # Invoke derived class to provide playback data
@@ -257,6 +258,7 @@ class CommonQuerySkill(OVOSSkill):
         if message.data["skill_id"] != self.skill_id:
             # Not for this skill!
             return
+        self.activate()
         phrase = message.data["phrase"]
         data = message.data.get("callback_data") or {}
         if data.get("answer"):

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -377,6 +377,7 @@ class FallbackSkillV2(_MetaFB, metaclass=_MutableFallback):
                     # indicate completion
                     status = True
                     handler_name = get_handler_name(handler)
+                    self.activate()  # activate skill for converse
                     break
             except Exception:
                 LOG.exception('Exception in fallback.')
@@ -388,9 +389,7 @@ class FallbackSkillV2(_MetaFB, metaclass=_MutableFallback):
             data={"result": status, "fallback_handler": handler_name}))
 
     def _old_register_fallback(self, handler: callable, priority: int):
-        """
-        makes the skill active, done by core >= 0.0.8
-        """
+        """ core < 0.0.8 """
 
         LOG.info(f"registering fallback handler -> "
                  f"ovos.skills.fallback.{self.skill_id}")
@@ -416,7 +415,6 @@ class FallbackSkillV2(_MetaFB, metaclass=_MutableFallback):
         @param handler: Fallback handler
         @param priority: priority of the registered handler
         """
-
         LOG.info(f"registering fallback handler -> "
                  f"ovos.skills.fallback.{self.skill_id}")
         self._fallback_handlers.append((priority, handler))

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1081,7 +1081,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         self.add_event("skill.converse.request", self._handle_converse_request,
                        speak_errors=False)
         self.add_event(f"{self.skill_id}.converse.request", self._handle_converse_request,
-                       speak_errors=False)
+                       speak_errors=False, activation=True)
         self.add_event(f"{self.skill_id}.activate", self.handle_activate,
                        speak_errors=False)
         self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate,
@@ -1103,7 +1103,8 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
 
         # TODO: deprecate 0.0.9
         self.add_event("skill.converse.get_response", self.__handle_get_response, speak_errors=False)
-        self.add_event(f"{self.skill_id}.converse.get_response", self.__handle_get_response, speak_errors=False)
+        self.add_event(f"{self.skill_id}.converse.get_response", self.__handle_get_response,
+                       speak_errors=False, activation=True)
 
     def _send_public_api(self, message: Message):
         """
@@ -1418,7 +1419,8 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
             filename = str(resource_file.file_path)
             self.intent_service.register_padatious_intent(name, filename, lang)
         if handler:
-            self.add_event(name, handler, 'mycroft.skill.handler')
+            self.add_event(name, handler, 'mycroft.skill.handler',
+                           activation=True)
 
     def register_entity_file(self, entity_file: str):
         """
@@ -1514,15 +1516,21 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         self.remove_context(context)
 
     def _on_event_start(self, message: Message, handler_info: str,
-                        skill_data: dict):
+                        skill_data: dict, activation: Optional[bool] = None):
         """
         Indicate that the skill handler is starting.
+
+        activation  (bool, optional): activate skill if True, deactivate if False, do nothing if None
         """
         if handler_info:
             # Indicate that the skill handler is starting if requested
             msg_type = handler_info + '.start'
             message.context["skill_id"] = self.skill_id
             self.bus.emit(message.forward(msg_type, skill_data))
+        if activation is True:
+            self.activate()
+        elif activation is False:
+            self.deactivate()
 
     def _on_event_end(self, message: Message, handler_info: str,
                       skill_data: dict):
@@ -1591,7 +1599,8 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         self.intent_service.register_adapt_intent(name, intent_parser)
         if handler:
             self.add_event(intent_parser.name, handler,
-                           'mycroft.skill.handler')
+                           'mycroft.skill.handler',
+                           activation=True)
 
     # skill developer facing utils
     def speak(self, utterance: str, expect_response: bool = False,
@@ -2219,7 +2228,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
     # event related skill developer facing utils
     def add_event(self, name: str, handler: callable,
                   handler_info: Optional[str] = None, once: bool = False,
-                  speak_errors: bool = True):
+                  speak_errors: bool = True, activation: Optional[bool] = None):
         """
         Create event handler for executing intent or other event.
 
@@ -2233,6 +2242,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
             speak_errors (bool, optional): Determines if an error dialog should be
                                            spoken to inform the user whenever
                                            an exception happens inside the handler
+            activation  (bool, optional): activate skill if True, deactivate if False, do nothing if None
         """
         skill_data = {'name': get_handler_name(handler)}
 
@@ -2245,7 +2255,8 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
                                  speak_errors)
 
         def on_start(message):
-            self._on_event_start(message, handler_info, skill_data)
+            self._on_event_start(message, handler_info,
+                                 skill_data, activation)
 
         def on_end(message):
             self._on_event_end(message, handler_info, skill_data)

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -2394,13 +2394,6 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
                                "timeout": duration_minutes})
         self.bus.emit(m1)
 
-        # backwards compat with mycroft-core
-        # TODO - remove soon
-        m2 = msg.forward("active_skill_request",
-                         data={"skill_id": self.skill_id,
-                               "timeout": duration_minutes})
-        self.bus.emit(m2)
-
     def deactivate(self):
         """
         Mark this skill as inactive and remove from the active skills list.


### PR DESCRIPTION
when using `self.add_event` we can now request that BEFORE the handler fires the skill is `activated` or `deactivated`

once this is adopted in core this line should be deleted https://github.com/OpenVoiceOS/ovos-core/blob/dev/ovos_core/intent_services/__init__.py#L296

and that will fix https://github.com/OpenVoiceOS/ovos-core/issues/450 (test need to be updated)

before either PR the event order is messy (extra messages omitted) 
```
"recognizer_loop:utterance",   
f"{skill_id}:{intent_name}",  # intent trigger
"mycroft.skill.handler.start", # intent start
(...)  # intent code, speak messages etc
"mycroft.skill.handler.complete",  # intent end
"intent.service.skills.activated",  # skill activation (from core)
f"{self.skill_id}.activate",  # skill callback
"ovos.session.update_default", # session update (end of utterance default sync)
```

with BOTH PRs the new events order becomes
```
"recognizer_loop:utterance", 
f"{skill_id}:{intent_name}",  # intent trigger
"mycroft.skill.handler.start",  # intent start
"intent.service.skills.activate",  # request (from workshop)
"intent.service.skills.activated",  # response (from core)
f"{self.skill_id}.activate",  # skill callback
"ovos.session.update_default",  # session update (active skill list ync)
(...)  # intent code, speak messages etc
"mycroft.skill.handler.complete",  # intent end
"ovos.session.update_default",  # session update (end of utterance default sync)
```

and now we can use deactivate inside skills as documentation says
```python
@intent_handler("my_intent.intent")
def handle_intent(self, message):
     self.deactivate()

def converse(self, message):
	 if self.asked_to_stop:
     	self.deactivate()
     return True	
```

this PR should be merged first, there is no consequence for older core versions, just means an extra activation event will be emitted, that should be harmless and only happen on partial updates (update workshop but not ovos-core)

