### PR TITLE
chore: don't drag ovos-classifiers

### DIFF
--- a/ovos_workshop/skills/common_play.py
+++ b/ovos_workshop/skills/common_play.py
@@ -7,7 +7,6 @@ from ovos_utils import camel_case_split
 from ovos_utils.log import LOG
 
 from ovos_bus_client import Message
-from ovos_classifiers.skovos.features import KeywordFeatures
 from ovos_config.locations import get_xdg_cache_save_path
 from ovos_workshop.skills.ovos import OVOSSkill
 
@@ -205,6 +204,7 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
             film_genre,spy film
             ...
         """
+        from ovos_classifiers.skovos.features import KeywordFeatures
         if lang is None:
             for lang in self.native_langs:
                 if lang not in self.ocp_matchers:
@@ -240,6 +240,7 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
         ocp keywords can be efficiently matched with self.ocp_match helper method
         that uses Aho–Corasick algorithm
         """
+        from ovos_classifiers.skovos.features import KeywordFeatures
         samples = list(set(samples))
         langs = langs or self.native_langs
         for l in langs:

--- a/requirements/ocp.txt
+++ b/requirements/ocp.txt
@@ -1,1 +1,2 @@
 ovos_plugin_common_play
+ovos_classifiers>=0.0.0a46

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,4 @@ ovos-bus-client < 0.1.0, >=0.0.9a20
 ovos_config < 0.2.0,>=0.0.12
 ovos_backend_client < 0.2.0, >=0.1.0
 ovos-lingua-franca~=0.4, >=0.4.6
-ovos_classifiers>=0.0.0a46
 rapidfuzz


### PR DESCRIPTION
ovos-classifiers is only used in two functions, and some lightweight utilities that use workshop don't need all its dependencies. Moves the import to those specific functions and makes classifiers part of the ocp extras