### PR TITLE
fix/fallback_timeout_handling

### DIFF
--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -360,8 +360,8 @@ class FallbackSkillV2(_MetaFB, metaclass=_MutableFallback):
     def _on_timeout(self):
         message = dig_for_message()
         self.bus.emit(message.forward(
-            f"ovos.skills.fallback.{self.skill_id}.response",
-            data={"result": False, "error": "timed out"}))
+            f"ovos.skills.fallback.{self.skill_id}.killed",
+            data={"error": "timed out"}))
 
     @killable_event("ovos.skills.fallback.force_timeout", callback=_on_timeout)
     def _handle_fallback_request(self, message: Message):

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -16,13 +16,14 @@ import operator
 from typing import Optional, List, Callable, Tuple
 
 from ovos_bus_client import MessageBusClient
-from ovos_bus_client.message import Message
+from ovos_bus_client.message import Message, dig_for_message
 from ovos_config import Configuration
 from ovos_utils.events import get_handler_name
 from ovos_utils.log import LOG
 from ovos_utils.metrics import Stopwatch
 from ovos_utils.skills import get_non_properties
 
+from ovos_workshop.decorators.killable import killable_event
 from ovos_workshop.decorators.compat import backwards_compat
 from ovos_workshop.permissions import FallbackMode
 from ovos_workshop.skills.ovos import OVOSSkill
@@ -356,6 +357,13 @@ class FallbackSkillV2(_MetaFB, metaclass=_MutableFallback):
                   "can_handle": self.can_answer(utts, lang)},
             context={"skill_id": self.skill_id}))
 
+    def _on_timeout(self):
+        message = dig_for_message()
+        self.bus.emit(message.forward(
+            f"ovos.skills.fallback.{self.skill_id}.response",
+            data={"result": False, "error": "timed out"}))
+
+    @killable_event("ovos.skills.fallback.force_timeout", callback=_on_timeout)
     def _handle_fallback_request(self, message: Message):
         """
         Handle a fallback request, calling any registered handlers in priority

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -145,7 +145,7 @@ class TestBaseSkill(unittest.TestCase):
             stop_time = time()
             stop_event.set()
             thread.join()
-            self.assertAlmostEquals(self.skill.settings["test_val"], stop_time,
+            self.assertAlmostEqual(self.skill.settings["test_val"], stop_time,
                                     0, f"run {i}")
             self.assertNotEqual(self.skill.settings["test_val"],
                                 self.skill._initial_settings["test_val"],

--- a/test/unittests/skills/test_fallback_skill.py
+++ b/test/unittests/skills/test_fallback_skill.py
@@ -1,3 +1,4 @@
+import time
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
@@ -262,6 +263,8 @@ class TestFallbackSkillV2(TestCase):
         self.fallback_skill._fallback_handlers = [(100, mock_handler)]
 
         self.fallback_skill._handle_fallback_request(Message("test"))
+        time.sleep(0.2)  # above runs in a killable thread
+
         self.assertTrue(start_event.is_set())
         self.assertTrue(handler_event.is_set())
 


### PR DESCRIPTION
by using a killable_event we can abort fallbacks that timedout avoiding multiple answers

closes https://github.com/OpenVoiceOS/ovos-core/issues/389

also avoids sessions being able to kill each other's events, could be problematic in get_response and company