### PR TITLE
feat/get_response_dynamic_timeout

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1856,6 +1856,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         ans = []
 
         start = time.time()
+        timeout = self.config_core.get("skills", {}).get("get_response_timeout", 20)
 
         def on_extension(msg):
             nonlocal start
@@ -1863,13 +1864,13 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
             if s.session_id == session.session_id:
                 # this helps with slower voice satellites or in cases of very long responses
                 LOG.debug(f"Extending get_response wait time: {msg.msg_type}")
-                start = time.time()
+                start = time.time()  # reset timer
 
         # if we have indications listener is busy, we allow extra time
         self.bus.on("recognizer_loop:record_begin", on_extension)
         self.bus.on("recognizer_loop:record_end", on_extension)
 
-        while time.time() - start <= 15 and not ans:
+        while time.time() - start <= timeout and not ans:
             ans = self.__responses[session.session_id]
             # NOTE: a threading.Event is not used otherwise we can't raise the
             # AbortEvent exception to kill the thread


### PR DESCRIPTION
ensure get_response doesnt timeout if we have indication the listener is still recording

extend default timeout to 20 seconds

this gives a larger time window for users to react to prompts from OVOS

relates to https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/125 , the state there was meant to alleviate the same issue