### PR TITLE
fix/wrong_log_due_identation_error

### DIFF
--- a/ovos_workshop/skills/common_play.py
+++ b/ovos_workshop/skills/common_play.py
@@ -504,8 +504,8 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
                         found = True
                         if self._stop_event.is_set():
                             break
-            else:  # skip this skill, it doesn't handle this media type
-                LOG.debug(f"skipping {self.skill_id}, it does not support media type: {media_type}")
+        else:  # skip this skill, it doesn't handle this media type
+            LOG.debug(f"skipping {self.skill_id}, it does not support media type: {media_type}")
 
         if not found:
             # Signal we are done (can't handle it)


### PR DESCRIPTION
an error log was always logged on success instead of on failure due to an indentation error

> 2024-07-11 22:20:17.923 - skills - ovos_workshop.skills.common_play:__handle_ocp_query:491 - DEBUG - skipping skill-ovos-youtube-music.openvoiceos, it does not support media type: 2
