### PR TITLE
fix/featured_media

### DIFF
--- a/ovos_workshop/skills/common_play.py
+++ b/ovos_workshop/skills/common_play.py
@@ -534,6 +534,8 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
         else:
             # inject skill id in individual results
             for idx, r in enumerate(results):
+                if isinstance(r, (MediaEntry, Playlist, PluginStream)):
+                    results[idx] = r.as_dict
                 results[idx]["skill_id"] = self.skill_id
             self.bus.emit(Message("ovos.common_play.skill.play",
                                   {"skill_id": self.skill_id,


### PR DESCRIPTION
needs to serialize MediaEntry to dict before emitting bus message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured consistency in data structure by converting specific objects to dictionaries before updating them. This enhances reliability when handling media entries, playlists, and plugin streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->