### PR TITLE
fix:wait while speaking

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1677,7 +1677,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
         self.bus.emit(m)
 
         if wait:
-            timeout = wait if isinstance(wait, int) else 15
+            timeout = 15 if isinstance(wait, bool) else wait
             sess = SessionManager.get(m)
             sess.is_speaking = True
             SessionManager.wait_while_speaking(timeout, sess)

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1724,7 +1724,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
                                            "uri": filename  # new namespace
                                            }))
             if wait:
-                timeout = wait if isinstance(wait, int) else 30
+                timeout = 30 if isinstance(wait, bool) else wait
                 sess = SessionManager.get(message)
                 sess.is_speaking = True
                 SessionManager.wait_while_speaking(timeout, sess)
@@ -1769,7 +1769,7 @@ class OVOSSkill(metaclass=_OVOSSkillMetaclass):
 
         self.bus.emit(message.forward(mtype, data))
         if wait:
-            timeout = wait if isinstance(wait, int) else 30
+            timeout = 30 if isinstance(wait, bool) else wait
             sess = SessionManager.get(message)
             sess.is_speaking = True
             SessionManager.wait_while_speaking(timeout, sess)


### PR DESCRIPTION
didnt realize bools were considered a type of int

```python
isinstance(True, int)
True
isinstance(False, int)
True
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved logic for setting timeout values in audio playback and speaking methods, enhancing responsiveness based on user input.
- **Bug Fixes**
	- Resolved issues related to timeout duration assignments, ensuring consistent behavior across different methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->