### PR TITLE
fix:langcodes

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
-ovos-utils>=0.0.38,<1.0.0
+ovos-utils>= 0.2.1,<1.0.0
 ovos_bus_client>=0.0.8,<1.0.0
 ovos-config>=0.0.12,<1.0.0
 ovos-backend-client>=0.1.0,<2.0.0
 ovos-lingua-franca>=0.4.6,<1.0.0
 rapidfuzz
+langcodes

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -573,12 +573,3 @@ class TestSkillGui(unittest.TestCase):
             config=old_skill.config_core['gui'],
             ui_directories={"qt5": join(old_skill.root_dir, "ui")})
 
-        # New skill with `gui` directory in root
-        new_skill = self.GuiSkill()
-        new_gui = SkillGUI(new_skill)
-        self.assertEqual(new_gui.skill, new_skill)
-        self.assertIsInstance(new_gui, GUIInterface)
-        interface_init.assert_called_with(
-            new_gui, skill_id=new_skill.skill_id, bus=new_skill.bus,
-            config=new_skill.config_core['gui'],
-            ui_directories={"all": join(new_skill.root_dir, "gui")})


### PR DESCRIPTION
the lang code standard assumes region is upper case, however mycroft forced a lower case lang code which is now causing issues if the standard is used

besides handling this, dialect support is now improved by using langcodes library distance function, ensuring the best dialect is selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced language resource management for improved directory handling.
	- Introduced a scoring mechanism for assessing language code similarities.

- **Bug Fixes**
	- Updated logic for determining the appropriate language resource directory.

- **Documentation**
	- Added deprecation warnings for certain parameters and functions to improve clarity.
	- Updated comments to reflect changes in language directory handling.

- **Chores**
	- Updated version constraint for the `ovos-utils` package and added a new dependency, `langcodes`.
  
- **Tests**
	- Removed test case for the new skill GUI implementation while retaining legacy skill GUI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->