### PR TITLE
fix:handle misc files and folder names mixed with lang folder

### DIFF
--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -84,13 +84,17 @@ def locate_lang_directories(lang: str, skill_directory: str,
     for directory in base_dirs:
         if directory.exists():
             for folder in directory.iterdir():
-                score = tag_distance(lang, folder.name)
-                # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-                # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-                # 1- 3 -> These codes indicate a minor regional difference.
-                # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
-                if score < 10:
-                    candidates.append((folder, score))
+                if folder.is_dir():
+                    try:
+                        score = tag_distance(lang, folder.name)
+                    except:  # not a valid language code
+                        continue
+                    # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
+                    # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
+                    # 1- 3 -> These codes indicate a minor regional difference.
+                    # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
+                    if score < 10:
+                        candidates.append((folder, score))
     # sort by distance to target lang code
     candidates = sorted(candidates, key=lambda k: k[1])
     return [c[0] for c in candidates]


### PR DESCRIPTION
if the resouces dir contained files or folder that aren't valid lang codes the score calculation would throw an exception

introduced in #241 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in language directory location functionality to prevent runtime errors from invalid folder names.
  
- **New Features**
	- Added deprecation log for the `resolve_resource_file` method to inform users of its new location in `ovos_utils.file_utils`.

- **Documentation**
	- Updated method signatures for clarity without changing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->