### PR TITLE
fix:lingua_franca

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1999,7 +1999,17 @@ class OVOSSkill:
             'no', including a response of None.
         """
         resp = self.get_response(dialog=prompt, data=data)
-        answer = yes_or_no(resp, lang=self.lang) if resp else resp
+        # TODO - lingua_franca does not support standardized lang tags
+        #  deprecate it, use a plugin here https://github.com/TigreGotico/ovos-solver-YesNo-plugin
+        lf_langs = ("az-az", "ca-es", "cs-cz", "da-dk", "de-de",
+                    "en-us", "es-es", "fr-fr",
+                    "hu-hu", "it-it", "nl-nl", "pl-pl",
+                    "fa-ir", "pt-pt", "ru-ru", "sl-si",
+                    "sv-se", "tr-tr", "eu-eu", "uk-ua")
+        lang, score = closest_match(self.lang, lf_langs)
+        if score > 10:
+            lang = self.lang  # let it raise a value Error in next line
+        answer = yes_or_no(resp, lang=lang) if resp else resp
         if answer is True:
             return "yes"
         elif answer is False:


### PR DESCRIPTION
lingua franca requires lowercased lang codes, which causes ask_yesno to fail

adds better dialect support

closes https://github.com/OpenVoiceOS/OVOS-workshop/issues/256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced language handling for yes/no responses in the `ask_yesno` method, improving localization support.

- **Bug Fixes**
	- Addressed potential issues with language matching, ensuring more accurate yes/no responses.

- **Documentation**
	- Updated comments to indicate future changes towards a plugin-based approach for handling yes/no queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->