### PR TITLE
fix:duplicate_handled_message

### DIFF
--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -199,9 +199,6 @@ class FallbackSkill(OVOSSkill):
         self.bus.emit(message.forward(
             f"ovos.skills.fallback.{self.skill_id}.response",
             data={"result": status, "fallback_handler": handler_name}))
-        if status:
-            self.bus.emit(message.forward("ovos.utterance.handled",
-                                          {"handler": handler_name}))
 
     def register_fallback(self, handler: callable, priority: int):
         """


### PR DESCRIPTION
ovos.utterance.handled is now emitted by the fallback pipeline, the skill class should not emit it or we get duplicate events

noticed in end2end tests from https://github.com/OpenVoiceOS/ovos-core/pull/571