### PR TITLE
feat:skilljson and homescreen

### DIFF
--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -1,5 +1,5 @@
 from functools import wraps
-
+from typing import Optional
 from ovos_utils.log import log_deprecation
 
 from ovos_workshop.decorators.killable import killable_intent, killable_event
@@ -159,19 +159,21 @@ def fallback_handler(priority: int = 50):
     return real_decorator
 
 
-def homescreen_app(icon: str):
+def homescreen_app(icon: str, name: Optional[str] = None):
     """
     Decorator for adding a method as a homescreen app
 
     the icon file MUST be located under 'gui' subfolder
 
     @param icon: icon file to use in app drawer (relative to "gui" folder)
+    @param name: short name to show under the icon in app drawer
     """
 
     def real_decorator(func):
         # Store the icon inside the function
         # This will be used later to call register_homescreen_app
-        func.homescreen_icon = icon
+        func.homescreen_app_icon = icon
+        func.homescreen_app_name = name
         return func
 
     return real_decorator

--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -157,3 +157,21 @@ def fallback_handler(priority: int = 50):
         return func
 
     return real_decorator
+
+
+def homescreen_app(icon: str):
+    """
+    Decorator for adding a method as a homescreen app
+
+    the icon file MUST be located under 'gui' subfolder
+
+    @param icon: icon file to use in app drawer (relative to "gui" folder)
+    """
+
+    def real_decorator(func):
+        # Store the icon inside the function
+        # This will be used later to call register_homescreen_app
+        func.homescreen_icon = icon
+        return func
+
+    return real_decorator

--- a/ovos_workshop/res/text/en/skill.error.dialog
+++ b/ovos_workshop/res/text/en/skill.error.dialog
@@ -1,0 +1,1 @@
+An error occurred while processing a request in {skill}

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -59,8 +59,7 @@ def locate_base_directories(skill_directory: str,
     """
     base_dirs = [Path(skill_directory, resource_subdirectory)] if \
         resource_subdirectory else []
-    base_dirs += [Path(skill_directory, "locale"),
-                  Path(skill_directory, "text")]
+    base_dirs += [Path(skill_directory, "locale")]
     candidates = []
     for directory in base_dirs:
         if directory.exists():
@@ -79,8 +78,7 @@ def locate_lang_directories(lang: str, skill_directory: str,
     @param resource_subdirectory: optional extra resource directory to prepend
     @return: list of existing skill resource directories for the given lang
     """
-    base_dirs = [Path(skill_directory, "locale"),
-                 Path(skill_directory, "text")]
+    base_dirs = [Path(skill_directory, "locale")]
     if resource_subdirectory:
         base_dirs.append(Path(skill_directory, resource_subdirectory))
     candidates = []
@@ -101,41 +99,6 @@ def locate_lang_directories(lang: str, skill_directory: str,
     # sort by distance to target lang code
     candidates = sorted(candidates, key=lambda k: k[1])
     return [c[0] for c in candidates]
-
-
-def resolve_resource_file(res_name: str) -> Optional[str]:
-    """Convert a resource into an absolute filename.
-
-    Resource names are in the form: 'filename.ext'
-    or 'path/filename.ext'
-
-    The system wil look for $XDG_DATA_DIRS/mycroft/res_name first
-    (defaults to ~/.local/share/mycroft/res_name), and if not found will
-    look at /opt/mycroft/res_name, then finally it will look for res_name
-    in the 'mycroft/res' folder of the source code package.
-
-    Example:
-        With mycroft running as the user 'bob', if you called
-        ``resolve_resource_file('snd/beep.wav')``
-        it would return either:
-        '$XDG_DATA_DIRS/mycroft/beep.wav',
-        '/home/bob/.mycroft/snd/beep.wav' or
-        '/opt/mycroft/snd/beep.wav' or
-        '.../mycroft/res/snd/beep.wav'
-        where the '...' is replaced by the path
-        where the package has been installed.
-
-    Args:
-        res_name (str): a resource path/name
-
-    Returns:
-        (str) path to resource or None if no resource found
-    """
-    log_deprecation(f"This method has moved to `ovos_utils.file_utils`",
-                    "0.1.0")
-    from ovos_utils.file_utils import resolve_resource_file
-    config = Configuration()
-    return resolve_resource_file(res_name, config=config)
 
 
 def find_resource(res_name: str, root_dir: str, res_dirname: str,

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -257,18 +257,13 @@ class ResourceType:
             return
 
         # check for lang resources shipped by the skill
+        possible_directories = [Path(skill_directory, "locale", self.language)]
         if resource_subdirectory:
-            possible_directories = (
-                Path(skill_directory, "locale", self.language),
+            possible_directories += [
                 Path(skill_directory, resource_subdirectory, self.language),
-                Path(skill_directory, resource_subdirectory),
-                Path(skill_directory, "text", self.language),
-            )
-        else:
-            possible_directories = (
-                Path(skill_directory, "locale", self.language),
-                Path(skill_directory, "text", self.language),
-            )
+                Path(skill_directory, resource_subdirectory)
+            ]
+
         for directory in possible_directories:
             if directory.exists():
                 self.base_directory = directory
@@ -331,7 +326,6 @@ class ResourceFile:
         by the skill author.  Walk the directory and any subdirectories to
         find the resource file.
         """
-        from ovos_utils.file_utils import resolve_resource_file
         file_path = None
         if self.resource_name.endswith(self.resource_type.file_extension):
             file_name = self.resource_name
@@ -376,7 +370,6 @@ class ResourceFile:
 class QmlFile(ResourceFile):
     def _locate(self):
         """ QML files are special because we do not want to walk the directory """
-        from ovos_utils.file_utils import resolve_resource_file
         file_path = None
         if self.resource_name.endswith(self.resource_type.file_extension):
             file_name = self.resource_name
@@ -477,6 +470,7 @@ class VocabularyFile(ResourceFile):
 
 class IntentFile(ResourceFile):
     """Defines an intent file, which skill use to form intents."""
+
     def __init__(self, resource_type, resource_name):
         super().__init__(resource_type, resource_name)
         self.data = None
@@ -679,10 +673,10 @@ class SkillResources:
         dialog_file = DialogFile(self.types.dialog, name)
         dialog_file.data = data
         return dialog_file.load()
-    
+
     def load_intent_file(self, name: str,
-                               data: Optional[dict] = None,
-                               entities: bool = True) -> List[str]:
+                         data: Optional[dict] = None,
+                         entities: bool = True) -> List[str]:
         """
         Loads the contents of an intent file.
 
@@ -866,7 +860,7 @@ class SkillResources:
         )
 
         return skill_regexes
-    
+
     @classmethod
     def get_available_languages(cls, skill_directory: str) -> List[str]:
         """
@@ -893,22 +887,22 @@ class SkillResources:
         if language not in languages:
             raise ValueError(f"Language {language} not available for skill")
 
-        inventory = dict()        
+        inventory = dict()
         for type_ in self.types:
             if specific_type and type_.resource_type != specific_type:
                 continue
 
             inventory[type_.resource_type] = list()
-            
+
             # search all files in the directory and subdirectories and dump its name in a list
             base_dirs = locate_lang_directories(language, self.skill_directory)
             for directory in base_dirs:
                 for file in directory.iterdir():
                     if file.suffix == type_.file_extension:
                         inventory[type_.resource_type].append(file.stem)
-        
+
         inventory["languages"] = languages
-        
+
         return inventory
 
     @staticmethod

--- a/ovos_workshop/settings.py
+++ b/ovos_workshop/settings.py
@@ -116,7 +116,7 @@ class SkillSettingsManager:
     @requires_backend
     def upload(self, generate: bool = False):
         if not is_paired():
-            LOG.error("Device needs to be paired to upload settings")
+            LOG.debug("Device needs to be paired to upload settings")
             return
         self.remote_settings.settings = dict(self.skill.settings)
         if generate:
@@ -126,7 +126,7 @@ class SkillSettingsManager:
     @requires_backend
     def upload_meta(self, generate: bool = False):
         if not is_paired():
-            LOG.error("Device needs to be paired to upload settingsmeta")
+            LOG.debug("Device needs to be paired to upload settingsmeta")
             return
         if generate:
             self.remote_settings.settings = dict(self.skill.settings)
@@ -136,7 +136,7 @@ class SkillSettingsManager:
     @requires_backend
     def download(self):
         if not is_paired():
-            LOG.error("Device needs to be paired to download remote settings")
+            LOG.debug("Device needs to be paired to download remote settings")
             return
         self.remote_settings.download()
         # we do not update skill object settings directly

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -864,6 +864,7 @@ class OVOSSkill:
                                              event=event)
                 self.add_event(event, method, speak_errors=False)
 
+    @property
     def __skill_id2name(self) -> str:
         """helper to make a nice string out of a skill_id"""
         return (self.skill_id.split(".")[0].replace("_", " ").

--- a/test/unittests/test_resource_files.py
+++ b/test/unittests/test_resource_files.py
@@ -15,10 +15,6 @@ class TestResourceFiles(unittest.TestCase):
         from ovos_workshop.resource_files import locate_lang_directories
         # TODO
 
-    def test_resolve_resource_file(self):
-        from ovos_workshop.resource_files import resolve_resource_file
-        # TODO
-
     def test_find_resource(self):
         from ovos_workshop.resource_files import find_resource
         test_dir = join(dirname(__file__), "test_res")


### PR DESCRIPTION
register utterance examples from skill.json with homescreen

register handler with homescreen app drawer

companion to https://github.com/OpenVoiceOS/skill-ovos-homescreen/pull/130

example decorator usage from local media skill
```python
    @homescreen_app("ovos-file-browser.svg")
    @intent_handler("open.file.browser.intent")
    def show_home(self, message):
        """
        Show the file browser home page
        """
        self.gui.show_page("Browser", override_idle=120)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `homescreen_app` decorator for registering applications with an icon on the homescreen.
  - Added support for handling JSON resource files, enhancing resource management capabilities.
  - Implemented a `register_homescreen_app` method for skills to register application icons with the homescreen.
  - Added methods for managing skill metadata and app launchers during initialization.
  - Added a standardized error message for skill processing issues.

- **Bug Fixes**
  - Improved error handling and logging during the registration processes for skills and resources.
  - Adjusted logging levels for pairing requirement messages from error to debug, enhancing clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->