### PR TITLE
fix:icon file path

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -930,7 +930,10 @@ class OVOSSkill:
         # it is the only path assured to be accessible both by skills and GUI
         GUI_CACHE_PATH = get_xdg_cache_save_path('ovos_gui')
 
-        full_icon_path = f"{self.root_dir}/gui/{icon}"
+        full_icon_path = f"{self.res_dir}/gui/{icon}"
+        if not os.path.isfile(full_icon_path):
+            self.log.error(f"failed to register homescreen app, icon does not exist: {full_icon_path}")
+            return
         shared_path = f"{GUI_CACHE_PATH}/{self.skill_id}/{icon}"
         shutil.copy(full_icon_path, shared_path)
 


### PR DESCRIPTION
use self.res_dir not self.root_dir to allow non standard locations (eg. OCP)

allow skills to load even if icon is missing, but log an error and dont register app with homescreen

missed in #283 , need for https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/pull/152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced homescreen app registration by sourcing the icon from the resource directory.

- **Bug Fixes**
	- Added error handling to log messages when the icon file is not found, improving feedback for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->