### PR TITLE
feat:utterance_modifiers

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1697,7 +1697,7 @@ class OVOSSkill:
 
     def speak_dialog(self, key: str, data: Optional[dict] = None,
                      expect_response: bool = False, wait: Union[bool, int] = False,
-                     prerender_transform: Optional[Callable] = None):
+                     render_callback: Optional[Callable[[str, str], str]] = None):
         """
         Speak a random sentence from a dialog file.
 
@@ -1711,12 +1711,25 @@ class OVOSSkill:
             wait (Union[bool, int]): set to True to block while the text
                                      is being spoken for 15 seconds. Alternatively, set
                                      to an integer to specify a timeout in seconds.
+            render_callback (Optional[Callable[[str, str], str]]): A callable 
+                                                           function that 
+                                                           transforms the 
+                                                           utterance before 
+                                                           it is spoken. 
+                                                           The function 
+                                                           should accept 
+                                                           the utterance 
+                                                           string and the 
+                                                           language as input 
+                                                           and return the 
+                                                           modified string. 
+                                                           Defaults to None.
         """
         if self.dialog_renderer:
             data = data or {}
             utterance = self.dialog_renderer.render(key, data)
-            if prerender_transform is not None:
-                utterance = prerender_transform(utterance)
+            if render_callback is not None:
+                utterance = render_callback(utterance, self.lang)
             self.speak(
                 utterance,
                 expect_response, wait, meta={'dialog': key, 'data': data}

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1696,7 +1696,8 @@ class OVOSSkill:
             SessionManager.wait_while_speaking(timeout, sess)
 
     def speak_dialog(self, key: str, data: Optional[dict] = None,
-                     expect_response: bool = False, wait: Union[bool, int] = False):
+                     expect_response: bool = False, wait: Union[bool, int] = False,
+                     prerender_transform: Optional[Callable] = None):
         """
         Speak a random sentence from a dialog file.
 
@@ -1713,11 +1714,15 @@ class OVOSSkill:
         """
         if self.dialog_renderer:
             data = data or {}
+            utterance = self.dialog_renderer.render(key, data)
+            if prerender_transform is not None:
+                utterance = prerender_transform(utterance)
             self.speak(
-                self.dialog_renderer.render(key, data),
+                utterance,
                 expect_response, wait, meta={'dialog': key, 'data': data}
             )
         else:
+            # TODO - change this behaviour, speaking the dialog file name isn't that helpful!
             self.log.error(
                 'dialog_render is None, does the locale/dialog folder exist?'
             )


### PR DESCRIPTION
allow skills to access the utterance choosen by self.speak_dialog

either to modify it (eg, pronounce numbers) or just to passively monitor it

example usage https://github.com/OpenVoiceOS/ovos-skill-days-in-history/pull/18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `speak_dialog` method to allow custom transformations of spoken utterances through an optional `render_callback` parameter.
  
- **Documentation**
	- Updated comments and documentation for the `speak_dialog` method to reflect the new parameter and its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->