### PR TITLE
feat:common_query_decorator

### DIFF
--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -118,6 +118,22 @@ def skill_api_method(func: callable):
     return func
 
 
+def common_query():
+    """
+    Decorator for adding a method as an intent handler.
+    """
+
+    def real_decorator(func):
+        # mark the method as a common_query handler
+        if not hasattr(func, 'common_query'):
+            func.common_query = True
+
+        return func
+
+    return real_decorator
+
+
+
 def converse_handler(func):
     """
     Decorator for aliasing a method as the converse method

--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Optional
+from typing import Optional, Callable
 from ovos_utils.log import log_deprecation
 
 from ovos_workshop.decorators.killable import killable_intent, killable_event
@@ -118,16 +118,19 @@ def skill_api_method(func: callable):
     return func
 
 
-def common_query():
+# utterance, answer, lang
+CQCallback = Callable[[Optional[str], Optional[str], Optional[str]], None]
+
+
+def common_query(callback: Optional[CQCallback] = None):
     """
     Decorator for adding a method as an intent handler.
     """
 
     def real_decorator(func):
         # mark the method as a common_query handler
-        if not hasattr(func, 'common_query'):
-            func.common_query = True
-
+        func.common_query = True
+        func.cq_callback = callback
         return func
 
     return real_decorator

--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -126,7 +126,6 @@ def common_query(callback: Optional[CQCallback] = None):
     """
     Decorator for adding a method as an intent handler.
     """
-
     def real_decorator(func):
         # mark the method as a common_query handler
         func.common_query = True

--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -126,6 +126,7 @@ def common_query(callback: Optional[CQCallback] = None):
     """
     Decorator for adding a method as an intent handler.
     """
+
     def real_decorator(func):
         # mark the method as a common_query handler
         func.common_query = True

--- a/ovos_workshop/skills/common_query_skill.py
+++ b/ovos_workshop/skills/common_query_skill.py
@@ -59,6 +59,7 @@ class CommonQuerySkill(OVOSSkill):
     """
 
     def __init__(self, *args, **kwargs):
+        log_deprecation("'CommonQuerySkill' class has been deprecated, use @common_query decorator with regular OVOSSkill instead", "4.0.0")
         # these should probably be configurable
         self.level_confidence = {
             CQSMatchLevel.EXACT: 0.9,

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1050,7 +1050,7 @@ class OVOSSkill:
         to the `CQS_action` method.
         @param message: `question:action` message
         """
-        if message.data["skill_id"] != self.skill_id:
+        if not self._cq_handler or message.data["skill_id"] != self.skill_id:
             # Not for this skill!
             return
         data = message.data.get("callback_data") or {}

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1012,7 +1012,6 @@ class OVOSSkill:
             if hasattr(method, 'common_query'):
                 self._cq_handler = method
                 self._cq_callback = method.cq_callback
-                print(666, method.__dict__)
                 LOG.debug(f"Registering common query handler for: {self.skill_id} - callback: {self._cq_callback}")
                 self.__handle_common_query_ping(Message("ovos.common_query.ping"))
 


### PR DESCRIPTION
register common query handlers via decorators instead of requiring a subclass with magic method to override

closes #314 

companion skill PRs:
- https://github.com/OpenVoiceOS/ovos-skill-wolfie/pull/60
- https://github.com/OpenVoiceOS/ovos-skill-wikipedia/pull/86
- https://github.com/OpenVoiceOS/ovos-skill-ddg/pull/63
- https://github.com/OpenVoiceOS/ovos-skill-wikihow/pull/39
- https://github.com/OpenVoiceOS/ovos-skill-wordnet/pull/39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new decorator `common_query` for marking query handlers.
	- Enhanced skill's ability to handle common queries.
	- Introduced new methods for processing and responding to query events.

- **Improvements**
	- Updated skill initialization to recognize common query handlers.
	- Improved vocabulary matching robustness.
	- Added a ping response mechanism for query readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->