### PR TITLE
fix: stop DRY

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1166,7 +1166,7 @@ class OVOSSkill:
         """
         Register default messagebus event handlers
         """
-        self.add_event('mycroft.stop', self._handle_stop, speak_errors=False)
+        self.add_event('mycroft.stop', self._handle_session_stop, speak_errors=False)
         self.add_event(f"{self.skill_id}.stop", self._handle_session_stop, speak_errors=False)
         self.add_event(f"{self.skill_id}.stop.ping", self._handle_stop_ack, speak_errors=False)
 
@@ -1355,22 +1355,6 @@ class OVOSSkill:
         if data["result"]:
             self.__responses[sess.session_id] = None # abort any ongoing get_response
         self.bus.emit(message.reply(f"{self.skill_id}.stop.response", data))
-
-    def _handle_stop(self, message):
-        """Handler for the "mycroft.stop" signal. Runs the user defined
-        `stop()` method.
-        """
-        message.context['skill_id'] = self.skill_id
-        self.bus.emit(message.forward(self.skill_id + ".stop"))
-        sess = SessionManager.get(message)
-        try:
-            stopped = self.stop_session(sess) or self.stop() or False
-            LOG.debug(f"{self.skill_id} stopped: {stopped}")
-            if stopped:
-                self.bus.emit(message.reply("mycroft.stop.handled",
-                                            {"by": "skill:" + self.skill_id}))
-        except Exception as e:
-            self.log.exception(f'Failed to stop skill: {self.skill_id}: {e}')
 
     def default_shutdown(self):
         """


### PR DESCRIPTION
no need for 2 handlers, decrease complexity

the only difference is an emitted event that is not listened too anywhere

follow up on https://github.com/OpenVoiceOS/OVOS-workshop/pull/323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated skill stop event handling to use a more session-aware approach
  - Replaced general stop method with a session-specific stop method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->