### PR TITLE
added bus message mycroft.skill.ready

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -751,6 +751,7 @@ class OVOSSkill:
 
     def on_ready_status(self):
         LOG.info(f'{self.skill_id} is ready.')
+        self.bus.emit(Message("mycroft.skill.ready", {"id": self.skill_id}))
 
     def on_error_status(self, e='Unknown'):
         LOG.exception(f'{self.skill_id} initialization failed')


### PR DESCRIPTION
Emits a bus message, `mycroft.skill.ready` after each skill is loaded.  This allows for the skill to perform specific tasks after is is loaded correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced skill initialization now includes an automatic readiness notification that informs other system components once the skill is fully loaded, promoting smoother integration and coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->