### PR TITLE
refactor!: stop

### DIFF
--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -219,28 +219,34 @@ class ConversationalSkill(OVOSSkill):
     @abc.abstractmethod
     def can_answer(self, message: Message) -> bool:
         """
-        Determines if the skill can handle the given utterances in the specified language in the converse method.
+        Determine if the skill can handle the given utterance during the converse phase.
 
-        Override this method to implement custom logic for assessing whether the skill is capable of answering a query.
+        Override this method to implement custom logic for assessing whether the skill
+        is capable of answering the user's query based on the utterance and session context.
 
-        note: utterance transcriptions are available under message.data["utterances"]
-        session can be obtained via SessionManager.get(message), eg. for session.lang
+        Notes:
+            - Utterance transcriptions are available via `message.data["utterances"]`.
+            - The session (e.g., to access language) can be retrieved using:
+              `session = SessionManager.get(message)`.
+
+        Args:
+            message (Message): The message containing user utterances and metadata.
 
         Returns:
-            True if the skill can handle the query during converse; otherwise, False.
+            bool: True if the skill can handle the query during converse; False otherwise.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def converse(self, message: Message) -> bool:
+    def converse(self, message: Message):
         """
-        Override to handle an utterance before intent parsing while this skill
-        is active. Active skills are called in order of most recently used to
-        least recently used until one handles the converse request. If no skill
-        handles an utterance in `converse`, then the utterance will continue to
-        normal intent parsing.
-        @param message: Message containing user utterances to optionally handle
-        @return: True if the utterance was handled, else False
+        Handle the user's utterance if this skill was selected via `can_answer`.
+
+        This method is called only if `can_answer` returned True and the skill was chosen
+        to handle the user's input during a conversation.
+
+        Args:
+            message (Message): The message containing the user utterances to process.
         """
         raise NotImplementedError
 

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -78,15 +78,21 @@ class FallbackSkill(OVOSSkill):
     @abc.abstractmethod
     def can_answer(self, message: Message) -> bool:
         """
-        Determines if the skill can handle the given utterances in the specified language.
-        
-        Override this method to implement custom logic for assessing whether the skill is capable of answering a query. By default, returns True if any fallback handlers are registered.
-        
-        note: utterance transcriptions are available under message.data["utterances"]
-        session can be obtained via SessionManager.get(message), eg. for session.lang
+        Determine if the fallback skill is capable of handling the given utterance.
+
+        Override this method to define custom logic for whether the skill can respond
+        to a query when invoked as a fallback.
+
+        Notes:
+            - Utterance transcriptions are available in `message.data["utterances"]`.
+            - The session (e.g., for language detection) can be accessed via:
+              `session = SessionManager.get(message)`.
+
+        Args:
+            message (Message): The message containing the user's utterance and context.
 
         Returns:
-            True if the skill can handle the query; otherwise, False.
+            bool: True if the skill can respond to the query as a fallback; otherwise, False.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
require skills to report if they can be stopped or not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified docstrings for skill methods related to handling user utterances and fallback behavior.
  - Updated documentation to provide clearer guidance on accessing utterance transcriptions and session context.

- **New Features**
  - Introduced a required method for skills to indicate if they can be stopped based on the current context, replacing the previous property-based approach. Skills must now explicitly implement this logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->