### PR TITLE
fix!: rename can_answer -> can_converse

### DIFF
--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -217,7 +217,7 @@ class ConversationalSkill(OVOSSkill):
         return True
 
     @abc.abstractmethod
-    def can_answer(self, message: Message) -> bool:
+    def can_converse(self, message: Message) -> bool:
         """
         Determine if the skill can handle the given utterance during the converse phase.
 
@@ -240,9 +240,9 @@ class ConversationalSkill(OVOSSkill):
     @abc.abstractmethod
     def converse(self, message: Message):
         """
-        Handle the user's utterance if this skill was selected via `can_answer`.
+        Handle the user's utterance if this skill is active.
 
-        This method is called only if `can_answer` returned True and the skill was chosen
+        This method is called only if `can_converse` returned True and the skill was chosen
         to handle the user's input during a conversation.
 
         Args:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,4 +5,4 @@ ovos-solver-yes-no-plugin>=0.0.1,<1.0.0
 ovos-number-parser>=0.0.1,<1.0.0
 rapidfuzz
 langcodes
-padacioso
+padacioso>=1.0.0, <2.0.0


### PR DESCRIPTION
copy paste error from fallback skill class...

marked as breaking change for versioning consistency even if live for less than a day

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed a method to better reflect its role in conversational handling and updated related documentation for improved clarity.

- **Chores**
  - Updated dependency requirements to restrict the version range of a package for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->