### PR TITLE
fix: use list.remove() instead of list.pop() in whitelist_skill

### DIFF
--- a/ovos_workshop/permissions.py
+++ b/ovos_workshop/permissions.py
@@ -24,7 +24,7 @@ def whitelist_skill(skill, config=None):
     skills_config = config.get("skills", {})
     blacklisted_skills = skills_config.get("blacklisted_skills", [])
     if skill in blacklisted_skills:
-        blacklisted_skills.pop(skill)
+        blacklisted_skills.remove(skill)
         conf = {
             "skills": {
                 "blacklisted_skills": blacklisted_skills


### PR DESCRIPTION
## Summary

- `whitelist_skill()` called `blacklisted_skills.pop(skill)` passing a skill ID string as the argument
- `list.pop()` expects an integer index — this raises `TypeError` at runtime whenever a skill is whitelisted
- Fix: replace with `list.remove(skill)` which removes by value

## Test plan

- [ ] Call `whitelist_skill()` with a skill ID that is present in `blacklisted_skills` — should remove it and return `True`
- [ ] Call `whitelist_skill()` with a skill ID not in the list — should return `False` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill removal behavior in whitelist operations to correctly handle blacklisted skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->