### PR TITLE
refactor: migrate language matching & template expansion to ovos-spec-tools

### DIFF
--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -16,6 +16,7 @@
 import abc
 import json
 import re
+import warnings
 from collections import namedtuple
 from os import walk
 from os.path import dirname
@@ -23,10 +24,15 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Dict, Any
 
 from ovos_config.locations import get_xdg_data_save_path
-from ovos_spec_tools import expand, lang_distance
+from ovos_spec_tools import expand, lang_distance, render as _spec_render
 from ovos_utils import flatten_list
-from ovos_utils.dialog import MustacheDialogRenderer, load_dialogs
-from ovos_utils.log import LOG
+from ovos_utils.dialog import MustacheDialogRenderer
+from ovos_utils.log import LOG, deprecated
+
+from ovos_workshop.version import VERSION_MAJOR
+
+# removal version is computed from the current major, never hardcoded
+_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
 
 SkillResourceTypes = namedtuple(
     "SkillResourceTypes",
@@ -397,16 +403,40 @@ class DialogFile(ResourceFile):
 
         return dialogs
 
-    def render(self, dialog_renderer):
-        """Renders a random phrase from a dialog file.
+    def _load_raw(self) -> List[str]:
+        """Load the phrase lines without expanding variants or filling slots.
 
-        If no file is found, the requested phrase is returned as the string. This
-        will use the default language for translations.
+        Slot filling and ``(a|b)``/``[x]`` expansion are deferred to
+        :func:`ovos_spec_tools.render`, which the spec defines as the
+        conformant renderer.
+        """
+        phrases = []
+        if self.file_path is not None:
+            for line in self._read():
+                phrases.append(line.replace("{{", "{").replace("}}", "}"))
+        return phrases
+
+    def render(self, dialog_renderer=None):
+        """Renders a random phrase from this dialog file.
+
+        Phrases are loaded from this file and rendered with
+        :func:`ovos_spec_tools.render`: ``(a|b)``/``[x]`` variants are expanded
+        and ``{name}`` slots are filled from ``self.data``. If no file is found,
+        the requested phrase name is returned as a string (with dots replaced by
+        spaces), preserving the legacy fallback for missing dialogs.
+
+        Args:
+            dialog_renderer: unused, kept for backwards compatibility.
 
         Returns:
-            str: a randomized version of the phrase
+            str: a randomized, rendered version of the phrase
         """
-        return dialog_renderer.render(self.resource_name, self.data)
+        phrases = self._load_raw()
+        if not phrases:
+            # legacy fallback for a missing dialog file:
+            # render("record.not.found") -> "record not found"
+            return self.resource_name.replace(".dialog", "").replace(".", " ")
+        return _spec_render(phrases, slots=self.data)
 
 
 class VocabularyFile(ResourceFile):
@@ -457,16 +487,28 @@ class IntentFile(ResourceFile):
                 intents = [intent.format(**self.data) for intent in intents]
         return intents
 
-    def render(self, dialog_renderer):
-        """Renders a random phrase from a dialog file.
+    def render(self, dialog_renderer=None):
+        """Renders a random phrase from this intent file.
 
-        If no file is found, the requested phrase is returned as the string. This
-        will use the default language for translations.
+        Phrases are loaded from this file and rendered with
+        :func:`ovos_spec_tools.render`: ``(a|b)``/``[x]`` variants are expanded
+        and ``{name}`` slots are filled from ``self.data``. If no file is found,
+        the requested phrase name is returned as a string (with dots replaced by
+        spaces), preserving the legacy fallback for missing files.
+
+        Args:
+            dialog_renderer: unused, kept for backwards compatibility.
 
         Returns:
-            str: a randomized version of the phrase
+            str: a randomized, rendered version of the phrase
         """
-        return dialog_renderer.render(self.resource_name, self.data)
+        phrases = []
+        if self.file_path is not None:
+            for line in self._read():
+                phrases.append(line.replace("{{", "{").replace("}}", "}"))
+        if not phrases:
+            return self.resource_name.replace(".intent", "").replace(".", " ")
+        return _spec_render(phrases, slots=self.data)
 
 
 class NamedValueFile(ResourceFile):
@@ -559,10 +601,21 @@ class SkillResources:
         self.static = dict()
 
     @property
+    @deprecated("dialog_renderer is deprecated; dialog rendering is handled by "
+                "ovos_spec_tools.render via SkillResources.render_dialog. "
+                "This compat shim will be removed.", _REMOVAL_VERSION)
     def dialog_renderer(self) -> MustacheDialogRenderer:
         """
         Get a dialog renderer object for these resources
+
+        Deprecated: dialog rendering is now performed by
+        :func:`ovos_spec_tools.render` inside :meth:`render_dialog`. This
+        property is kept only as a compatibility shim and lazily builds a
+        :class:`MustacheDialogRenderer` for callers that still expect one.
         """
+        warnings.warn(
+            "dialog_renderer is deprecated; use SkillResources.render_dialog",
+            DeprecationWarning, stacklevel=3)
         if not self._dialog_renderer:
             self._load_dialog_renderer()
         return self._dialog_renderer
@@ -577,14 +630,22 @@ class SkillResources:
     def _load_dialog_renderer(self):
         """
         Initialize a MustacheDialogRenderer object for these resources
+
+        Deprecated compat helper: loads ``.dialog`` files into a
+        :class:`MustacheDialogRenderer` for legacy callers of the
+        :attr:`dialog_renderer` property. New code renders via
+        :func:`ovos_spec_tools.render`.
         """
         base_dirs = locate_lang_directories(self.language,
                                             self.skill_directory,
                                             "dialog")
         for directory in base_dirs:
             if directory.exists():
-                dialog_dir = str(directory)
-                self._dialog_renderer = load_dialogs(dialog_dir)
+                renderer = MustacheDialogRenderer()
+                for path in Path(directory).iterdir():
+                    if path.is_file() and path.suffix == ".dialog":
+                        renderer.load_template_file(path.stem, str(path))
+                self._dialog_renderer = renderer
                 return
         LOG.debug(f'No dialog loaded for {self.language}')
 
@@ -780,7 +841,7 @@ class SkillResources:
         """
         resource_file = DialogFile(self.types.dialog, name)
         resource_file.data = data
-        return resource_file.render(self.dialog_renderer)
+        return resource_file.render()
 
     def load_skill_vocabulary(self, alphanumeric_skill_id: str) -> dict:
         """

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -12,11 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Handling of skill data such as intents and regular expressions."""
+"""Handling of skill data such as intents and regular expressions.
+
+.. deprecated::
+    The whole :mod:`ovos_workshop.resource_files` module is deprecated and
+    will be removed in a future release. It predates the OVOS formal
+    specifications and is considered overengineered.
+
+    Use :mod:`ovos_spec_tools` instead:
+
+    * :class:`ovos_spec_tools.LocaleResources` replaces the resource loading
+      machinery (:class:`SkillResources`, :class:`ResourceFile` and friends).
+    * :func:`ovos_spec_tools.render` / :class:`ovos_spec_tools.DialogRenderer`
+      replace dialog rendering.
+    * :func:`ovos_spec_tools.expand` replaces template/variant expansion.
+    * :func:`ovos_spec_tools.closest_lang` / :func:`ovos_spec_tools.standardize_lang`
+      replace language matching.
+
+    The legacy resource types ``.qml``, ``.json``, ``.list``, ``.value``,
+    ``.rx`` (regex), ``.word`` and ``.template`` have no spec replacement;
+    they are legacy and not part of the OVOS formal specifications.
+
+    The module remains fully functional for downstream consumers; nothing has
+    been removed.
+"""
 import abc
 import json
 import re
+import sys
 import warnings
+import functools
 from collections import namedtuple
 from os import walk
 from os.path import dirname
@@ -33,6 +58,55 @@ from ovos_workshop.version import VERSION_MAJOR
 
 # removal version is computed from the current major, never hardcoded
 _REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
+
+def _caller_is_internal() -> bool:
+    """Return True when the deprecated entry point is being called by
+    ovos_workshop's own code.
+
+    Workshop instantiates these classes internally on hot paths (e.g.
+    :class:`SkillResources` is built per-skill, per-language). Firing a
+    deprecation warning for those internal calls would spam the logs at the
+    framework itself. The deprecation must stay visible to downstream users
+    but silent for workshop's own use, so the warning is guarded by this
+    stack inspection.
+    """
+    # frame 0: this function, frame 1: the deprecated wrapper -> walk outward
+    frame = sys._getframe(2)
+    while frame is not None:
+        module = frame.f_globals.get("__name__", "")
+        if module.startswith("ovos_workshop"):
+            return True
+        if module and not module.startswith("ovos_workshop"):
+            # the first non-workshop frame decides: external caller
+            return False
+        frame = frame.f_back
+    return False
+
+
+def _deprecated_public(msg: str):
+    """Decorator for public functions / ``__init__`` of public classes in this
+    module.
+
+    Combines the :func:`ovos_utils.log.deprecated` log notice with an inner
+    :class:`DeprecationWarning` (visible to IDEs/tooling), but suppresses both
+    when the caller is ovos_workshop itself (see :func:`_caller_is_internal`).
+    """
+    _decorated = deprecated(msg, _REMOVAL_VERSION)
+
+    def wrapped(func):
+        logged = _decorated(func)
+
+        @functools.wraps(func)
+        def log_wrapper(*args, **kwargs):
+            if _caller_is_internal():
+                return func(*args, **kwargs)
+            warnings.warn(msg, DeprecationWarning, stacklevel=3)
+            return logged(*args, **kwargs)
+
+        return log_wrapper
+
+    return wrapped
 
 SkillResourceTypes = namedtuple(
     "SkillResourceTypes",
@@ -52,6 +126,9 @@ SkillResourceTypes = namedtuple(
 )
 
 
+@_deprecated_public(
+    "locate_base_directories is deprecated; use ovos_spec_tools.LocaleResources "
+    "for resource discovery.")
 def locate_base_directories(skill_directory: str,
                             resource_subdirectory: Optional[str] = None) -> \
         List[Path]:
@@ -60,6 +137,9 @@ def locate_base_directories(skill_directory: str,
     @param skill_directory: skill base directory to search for resources
     @param resource_subdirectory: optional extra resource directory to prepend
     @return: list of existing skill resource directories
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource discovery.
     """
     base_dirs = [Path(skill_directory, resource_subdirectory)] if \
         resource_subdirectory else []
@@ -71,6 +151,10 @@ def locate_base_directories(skill_directory: str,
     return candidates
 
 
+@_deprecated_public(
+    "locate_lang_directories is deprecated; use ovos_spec_tools.closest_lang / "
+    "standardize_lang for language matching and ovos_spec_tools.LocaleResources "
+    "for resource discovery.")
 def locate_lang_directories(lang: str, skill_directory: str,
                             resource_subdirectory: Optional[str] = None) -> List[Path]:
     """
@@ -80,6 +164,11 @@ def locate_lang_directories(lang: str, skill_directory: str,
     @param skill_directory: skill base directory to search for resources
     @param resource_subdirectory: optional extra resource directory to prepend
     @return: list of existing skill resource directories for the given lang
+
+    .. deprecated::
+        Use :func:`ovos_spec_tools.closest_lang` / :func:`ovos_spec_tools.standardize_lang`
+        for language matching and :class:`ovos_spec_tools.LocaleResources`
+        for resource discovery.
     """
     base_dirs = [Path(skill_directory, "locale")]
     if resource_subdirectory:
@@ -102,10 +191,16 @@ def locate_lang_directories(lang: str, skill_directory: str,
     return [c[0] for c in candidates]
 
 
+@_deprecated_public(
+    "find_resource is deprecated; use ovos_spec_tools.LocaleResources for "
+    "resource discovery.")
 def find_resource(res_name: str, root_dir: str, res_dirname: str,
                   lang: Optional[str] = None) -> Optional[Path]:
     """
     Find a resource file.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource discovery.
 
     Searches for the given filename using this scheme:
         1. Search the resource lang directory:
@@ -157,8 +252,14 @@ class ResourceType:
         resource_type: one of a predefined set of resource types for skills
         file_extension: the file extension associated with the resource type
         base_directory: directory containing all files for the resource type
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource discovery.
     """
 
+    @_deprecated_public(
+        "ResourceType is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource discovery.")
     def __init__(self, resource_type: str, file_extension: str,
                  language: Optional[str] = None):
         self.resource_type = resource_type
@@ -274,8 +375,14 @@ class ResourceFile:
         resource_type: attributes of the resource type (dialog, vocab, etc.)
         resource_name: file name of the resource, with or without extension
         file_path: absolute path to the file
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading.
     """
 
+    @_deprecated_public(
+        "ResourceFile is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading.")
     def __init__(self, resource_type: ResourceType, resource_name: str):
         self.resource_type = resource_type
         self.resource_name = resource_name
@@ -337,6 +444,19 @@ class ResourceFile:
 
 
 class QmlFile(ResourceFile):
+    """Loads a ``.qml`` GUI resource file.
+
+    .. deprecated::
+        ``.qml`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "QmlFile is deprecated; .qml is a legacy resource type and is not part "
+        "of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
+
     def _locate(self):
         """ QML files are special because we do not want to walk the directory """
         file_path = None
@@ -369,6 +489,19 @@ class QmlFile(ResourceFile):
 
 
 class JsonFile(ResourceFile):
+    """Loads a ``.json`` resource file.
+
+    .. deprecated::
+        ``.json`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "JsonFile is deprecated; .json is a legacy resource type and is not "
+        "part of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
+
     def load(self) -> Dict[str, Any]:
         if self.file_path is not None:
             try:
@@ -380,8 +513,16 @@ class JsonFile(ResourceFile):
 
 
 class DialogFile(ResourceFile):
-    """Defines a dialog file, which is used instruct TTS what to speak."""
+    """Defines a dialog file, which is used instruct TTS what to speak.
 
+    .. deprecated::
+        Use :func:`ovos_spec_tools.render` / :class:`ovos_spec_tools.DialogRenderer`
+        for dialog rendering.
+    """
+
+    @_deprecated_public(
+        "DialogFile is deprecated; use ovos_spec_tools.render / "
+        "ovos_spec_tools.DialogRenderer for dialog rendering.")
     def __init__(self, resource_type, resource_name):
         super().__init__(resource_type, resource_name)
         self.data = None
@@ -442,7 +583,17 @@ class DialogFile(ResourceFile):
 
 
 class VocabularyFile(ResourceFile):
-    """Defines a vocabulary file, which skill use to form intents."""
+    """Defines a vocabulary file, which skill use to form intents.
+
+    .. deprecated::
+        Use :func:`ovos_spec_tools.expand` for vocabulary variant expansion.
+    """
+
+    @_deprecated_public(
+        "VocabularyFile is deprecated; use ovos_spec_tools.expand for "
+        "vocabulary variant expansion.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
 
     def load(self) -> List[List[str]]:
         """Loads a vocabulary file.
@@ -464,8 +615,15 @@ class VocabularyFile(ResourceFile):
 
 
 class IntentFile(ResourceFile):
-    """Defines an intent file, which skill use to form intents."""
+    """Defines an intent file, which skill use to form intents.
 
+    .. deprecated::
+        Use :func:`ovos_spec_tools.expand` / :func:`ovos_spec_tools.render`.
+    """
+
+    @_deprecated_public(
+        "IntentFile is deprecated; use ovos_spec_tools.expand / "
+        "ovos_spec_tools.render.")
     def __init__(self, resource_type, resource_name):
         super().__init__(resource_type, resource_name)
         self.data = None
@@ -517,8 +675,16 @@ class IntentFile(ResourceFile):
 
 
 class NamedValueFile(ResourceFile):
-    """Defines a named value file, which maps a variable to a values."""
+    """Defines a named value file, which maps a variable to a values.
 
+    .. deprecated::
+        ``.value`` is a legacy resource type and is not part of the OVOS
+        formal specifications.
+    """
+
+    @_deprecated_public(
+        "NamedValueFile is deprecated; .value is a legacy resource type and is "
+        "not part of the OVOS formal specifications.")
     def __init__(self, resource_type, resource_name):
         super().__init__(resource_type, resource_name)
         self.delimiter = ","
@@ -559,14 +725,50 @@ class NamedValueFile(ResourceFile):
 
 
 class ListFile(DialogFile):
-    pass
+    """Defines a ``.list`` file.
+
+    .. deprecated::
+        ``.list`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "ListFile is deprecated; .list is a legacy resource type and is not "
+        "part of the OVOS formal specifications.")
+    def __init__(self, resource_type, resource_name):
+        super().__init__(resource_type, resource_name)
 
 
 class TemplateFile(DialogFile):
-    pass
+    """Defines a ``.template`` file.
+
+    .. deprecated::
+        ``.template`` is a legacy resource type and is not part of the OVOS
+        formal specifications; use :func:`ovos_spec_tools.expand`.
+    """
+
+    @_deprecated_public(
+        "TemplateFile is deprecated; .template is a legacy resource type and "
+        "is not part of the OVOS formal specifications; use "
+        "ovos_spec_tools.expand.")
+    def __init__(self, resource_type, resource_name):
+        super().__init__(resource_type, resource_name)
 
 
 class RegexFile(ResourceFile):
+    """Defines a ``.rx`` regex resource file.
+
+    .. deprecated::
+        ``.rx`` (regex) is a legacy resource type and is not part of the OVOS
+        formal specifications.
+    """
+
+    @_deprecated_public(
+        "RegexFile is deprecated; .rx (regex) is a legacy resource type and is "
+        "not part of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
+
     def load(self):
         regex_patterns = []
         if self.file_path:
@@ -576,7 +778,18 @@ class RegexFile(ResourceFile):
 
 
 class WordFile(ResourceFile):
-    """Defines a word file, which defines a word in the configured language."""
+    """Defines a word file, which defines a word in the configured language.
+
+    .. deprecated::
+        ``.word`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "WordFile is deprecated; .word is a legacy resource type and is not "
+        "part of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
 
     def load(self) -> Optional[str]:
         """Load and lines from a file and populate the variables.
@@ -594,6 +807,16 @@ class WordFile(ResourceFile):
 
 
 class SkillResources:
+    """Loads and renders skill resource files.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading and
+        :func:`ovos_spec_tools.render` for dialog rendering.
+    """
+
+    @_deprecated_public(
+        "SkillResources is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading and ovos_spec_tools.render for dialog rendering.")
     def __init__(self, skill_directory: str,
                  language: str,
                  dialog_renderer: Optional[MustacheDialogRenderer] = None,
@@ -959,18 +1182,46 @@ class SkillResources:
 
 
 class CoreResources(SkillResources):
+    """Loads ovos-workshop's bundled core resources.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading.
+    """
+
+    @_deprecated_public(
+        "CoreResources is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading.")
     def __init__(self, language):
         directory = f"{dirname(__file__)}/locale"
         super().__init__(directory, language)
 
 
 class UserResources(SkillResources):
+    """Loads user-provided override resources.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading.
+    """
+
+    @_deprecated_public(
+        "UserResources is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading.")
     def __init__(self, language, skill_id):
         directory = f"{get_xdg_data_save_path()}/resources/{skill_id}"
         super().__init__(directory, language)
 
 
 class RegexExtractor:
+    """Extracts a named group from an utterance using regex patterns.
+
+    .. deprecated::
+        :class:`RegexExtractor` is legacy and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "RegexExtractor is deprecated; it is legacy and is not part of the "
+        "OVOS formal specifications.")
     def __init__(self, group_name: str, regex_patterns: List[str]):
         """
         Init an object representing an entity and a list of possible regex

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -421,21 +421,23 @@ class DialogFile(ResourceFile):
 
         Phrases are loaded from this file and rendered with
         :func:`ovos_spec_tools.render`: ``(a|b)``/``[x]`` variants are expanded
-        and ``{name}`` slots are filled from ``self.data``. If no file is found,
-        the requested phrase name is returned as a string (with dots replaced by
-        spaces), preserving the legacy fallback for missing dialogs.
+        and ``{name}`` slots are filled from ``self.data``.
 
         Args:
             dialog_renderer: unused, kept for backwards compatibility.
 
         Returns:
             str: a randomized, rendered version of the phrase
+
+        Raises:
+            FileNotFoundError: the ``.dialog`` resource does not exist or is
+                empty. A missing dialog is a skill bug — it is reported, not
+                silently rendered as the dialog name.
         """
         phrases = self._load_raw()
         if not phrases:
-            # legacy fallback for a missing dialog file:
-            # render("record.not.found") -> "record not found"
-            return self.resource_name.replace(".dialog", "").replace(".", " ")
+            raise FileNotFoundError(
+                f"missing or empty .dialog resource: {self.resource_name!r}")
         return _spec_render(phrases, slots=self.data)
 
 
@@ -492,22 +494,25 @@ class IntentFile(ResourceFile):
 
         Phrases are loaded from this file and rendered with
         :func:`ovos_spec_tools.render`: ``(a|b)``/``[x]`` variants are expanded
-        and ``{name}`` slots are filled from ``self.data``. If no file is found,
-        the requested phrase name is returned as a string (with dots replaced by
-        spaces), preserving the legacy fallback for missing files.
+        and ``{name}`` slots are filled from ``self.data``.
 
         Args:
             dialog_renderer: unused, kept for backwards compatibility.
 
         Returns:
             str: a randomized, rendered version of the phrase
+
+        Raises:
+            FileNotFoundError: the ``.intent`` resource does not exist or is
+                empty.
         """
         phrases = []
         if self.file_path is not None:
             for line in self._read():
                 phrases.append(line.replace("{{", "{").replace("}}", "}"))
         if not phrases:
-            return self.resource_name.replace(".intent", "").replace(".", " ")
+            raise FileNotFoundError(
+                f"missing or empty .intent resource: {self.resource_name!r}")
         return _spec_render(phrases, slots=self.data)
 
 

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -870,9 +870,8 @@ class SkillResources:
         for directory in base_dirs:
             if directory.exists():
                 renderer = MustacheDialogRenderer()
-                for path in Path(directory).iterdir():
-                    if path.is_file() and path.suffix == ".dialog":
-                        renderer.load_template_file(path.stem, str(path))
+                for path in Path(directory).rglob("*.dialog"):
+                    renderer.load_template_file(path.stem, str(path))
                 self._dialog_renderer = renderer
                 return
         LOG.debug(f'No dialog loaded for {self.language}')

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -22,10 +22,9 @@ from os.path import dirname
 from pathlib import Path
 from typing import List, Optional, Tuple, Dict, Any
 
-from langcodes import tag_distance
 from ovos_config.locations import get_xdg_data_save_path
+from ovos_spec_tools import expand, lang_distance
 from ovos_utils import flatten_list
-from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.dialog import MustacheDialogRenderer, load_dialogs
 from ovos_utils.log import LOG
 
@@ -85,13 +84,11 @@ def locate_lang_directories(lang: str, skill_directory: str,
             for folder in directory.iterdir():
                 if folder.is_dir():
                     try:
-                        score = tag_distance(lang, folder.name)
+                        score = lang_distance(lang, folder.name)
                     except ValueError:  # not a valid language code
                         continue
-                    # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-                    # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-                    # 1- 3 -> These codes indicate a minor regional difference.
-                    # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
+                    # lang_distance follows the OVOS-LANG spec: 0 is identical,
+                    # a value of 10 or more is not a usable match.
                     if score < 10:
                         candidates.append((folder, score))
     # sort by distance to target lang code
@@ -430,7 +427,7 @@ class VocabularyFile(ResourceFile):
         vocabulary = []
         if self.file_path is not None:
             for line in self._read():
-                vocabulary.append(expand_template(line.lower()))
+                vocabulary.append(sorted(expand(line.lower())))
         return vocabulary
 
 
@@ -453,7 +450,7 @@ class IntentFile(ResourceFile):
         if self.file_path is not None:
             for line in self._read():
                 line = line.replace("{{", "{").replace("}}", "}")
-                intents.extend(flatten_list(expand_template(line.lower())))
+                intents.extend(flatten_list(sorted(expand(line.lower()))))
             if not entities:
                 intents = [re.sub(r'{.*?}\s?', '', intent).strip() for intent in intents]
             elif self.data:

--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -2,7 +2,7 @@ import abc
 from inspect import signature
 from typing import Optional
 
-from langcodes import closest_match
+from ovos_spec_tools import closest_lang
 from ovos_bus_client.message import Message
 from ovos_bus_client.message import dig_for_message
 from ovos_config.config import Configuration
@@ -104,14 +104,9 @@ class ConversationalSkill(OVOSSkill):
 
     def _get_closest_lang(self, lang: str) -> Optional[str]:
         if self.converse_matchers:
-            lang = standardize_lang_tag(lang)
-            closest, score = closest_match(lang, list(self.converse_matchers.keys()))
-            # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-            # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-            # 1- 3 -> These codes indicate a minor regional difference.
-            # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
-            if score < 10:
-                return closest
+            # closest_lang follows the OVOS-LANG spec: it standardizes both
+            # sides and accepts a match only when the distance is below 10.
+            return closest_lang(lang, list(self.converse_matchers.keys()))
         return None
 
     def _handle_converse_ack(self, message: Message):

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -19,6 +19,7 @@ import shutil
 import sys
 import time
 import traceback
+import warnings
 from copy import copy
 from hashlib import md5
 from inspect import signature
@@ -51,7 +52,7 @@ from ovos_utils.file_utils import FileWatcher
 from ovos_utils.gui import get_ui_directories
 from ovos_utils.json_helper import merge_dict
 from ovos_utils.lang import standardize_lang_tag
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap, RuntimeRequirements
 from ovos_utils.skills import get_non_properties
 from ovos_utils.text_utils import remove_accents_and_punct
@@ -64,6 +65,7 @@ from ovos_workshop.intents import IntentBuilder, Intent, munge_regex, munge_inte
 from ovos_workshop.resource_files import ResourceFile, find_resource, SkillResources
 from ovos_workshop.settings import PrivateSettings
 from ovos_workshop.skills.util import join_word_list, simple_trace
+from ovos_workshop.version import VERSION_MAJOR
 
 
 class OVOSSkill:
@@ -421,13 +423,38 @@ class OVOSSkill:
 
     # magic properties -> depend on message.context / Session
     @property
+    @deprecated("dialog_renderer is deprecated; dialogs are rendered by "
+                "ovos_spec_tools.render via OVOSSkill.render_dialog / "
+                "self.resources.render_dialog. This compat shim will be "
+                "removed.", f"{VERSION_MAJOR + 1}.0.0")
     def dialog_renderer(self) -> Optional[MustacheDialogRenderer]:
         """
         Get a dialog renderer for this skill. Language will be determined by
         message history to match the language associated with the current
         session or else from Configuration.
+
+        Deprecated: dialog rendering is now performed by
+        :func:`ovos_spec_tools.render`. Use :meth:`render_dialog` (or
+        ``self.resources.render_dialog``) instead. This property is kept only
+        as a compatibility shim.
         """
+        warnings.warn(
+            "dialog_renderer is deprecated; use OVOSSkill.render_dialog",
+            DeprecationWarning, stacklevel=3)
         return self.resources.dialog_renderer
+
+    def render_dialog(self, name: str, data: Optional[dict] = None) -> str:
+        """
+        Render a random phrase from a ``.dialog`` file for the skill's current
+        language, filling ``{name}`` slots from ``data``.
+
+        Args:
+            name: name of the dialog file (no extension needed)
+            data: values used to fill the dialog's named slots
+        Returns:
+            A rendered phrase ready for text-to-speech.
+        """
+        return self.resources.render_dialog(name, data)
 
     @property
     def system_unit(self) -> str:
@@ -1589,21 +1616,17 @@ class OVOSSkill:
                                                            modified string. 
                                                            Defaults to None.
         """
-        if self.dialog_renderer:
-            data = data or {}
-            utterance = self.dialog_renderer.render(key, data)
-            if render_callback is not None:
-                utterance = render_callback(utterance, self.lang)
-            self.speak(
-                utterance,
-                expect_response, wait, meta={'dialog': key, 'data': data}
-            )
-        else:
-            # TODO - change this behaviour, speaking the dialog file name isn't that helpful!
-            self.log.error(
-                'dialog_render is None, does the locale/dialog folder exist?'
-            )
-            self.speak(key, expect_response, wait, {})
+        data = data or {}
+        # render_dialog renders a phrase via ovos_spec_tools.render; a missing
+        # .dialog file falls back to the dialog name with dots replaced by
+        # spaces (eg "record.not.found" -> "record not found").
+        utterance = self.render_dialog(key, data)
+        if render_callback is not None:
+            utterance = render_callback(utterance, self.lang)
+        self.speak(
+            utterance,
+            expect_response, wait, meta={'dialog': key, 'data': data}
+        )
 
     def play_audio(self, filename: str, instant: bool = False,
                    wait: Union[bool, int] = False):
@@ -1746,14 +1769,13 @@ class OVOSSkill:
         def on_fail_default(utterance):
             fail_data = data.copy()
             fail_data['utterance'] = utterance
+            # render_dialog renders a phrase via ovos_spec_tools.render; a
+            # missing .dialog file falls back to the name with dots replaced
+            # by spaces.
             if on_fail:
-                if self.dialog_renderer:
-                    return self.dialog_renderer.render(on_fail, fail_data)
-                return on_fail
+                return self.render_dialog(on_fail, fail_data)
             else:
-                if self.dialog_renderer:
-                    return self.dialog_renderer.render(dialog, data)
-                return dialog
+                return self.render_dialog(dialog, data)
 
         def is_cancel(utterance):
             return self.voc_match(utterance, 'cancel', lang=session.lang)

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -448,13 +448,21 @@ class OVOSSkill:
         Render a random phrase from a ``.dialog`` file for the skill's current
         language, filling ``{name}`` slots from ``data``.
 
+        ``name`` may also be a **literal utterance** rather than a dialog key:
+        ``speak_dialog`` / ``get_response`` accept either form, so if no
+        ``.dialog`` resource matches, ``name`` is returned verbatim.
+
         Args:
-            name: name of the dialog file (no extension needed)
+            name: a dialog file name (no extension), or a literal utterance
             data: values used to fill the dialog's named slots
         Returns:
             A rendered phrase ready for text-to-speech.
         """
-        return self.resources.render_dialog(name, data)
+        try:
+            return self.resources.render_dialog(name, data)
+        except FileNotFoundError:
+            # `name` is not a dialog key — treat it as a literal utterance
+            return name
 
     @property
     def system_unit(self) -> str:
@@ -1617,9 +1625,9 @@ class OVOSSkill:
                                                            Defaults to None.
         """
         data = data or {}
-        # render_dialog renders a phrase via ovos_spec_tools.render; a missing
-        # .dialog file falls back to the dialog name with dots replaced by
-        # spaces (eg "record.not.found" -> "record not found").
+        # render_dialog renders a phrase via ovos_spec_tools.render; `key` may
+        # also be a literal utterance — if no .dialog file matches it, it is
+        # spoken verbatim.
         utterance = self.render_dialog(key, data)
         if render_callback is not None:
             utterance = render_callback(utterance, self.lang)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [{name = "jarbasAi", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 dependencies = [
     "ovos-utils>= 0.7.0,<1.0.0",
+    "ovos-spec-tools>=0.0.1a2",
     "ovos_bus_client>=1.3.8a1,<2.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-yes-no-plugin>=0.3.0,<1.0.0",


### PR DESCRIPTION
Wave 2 of the OVOS-wide migration onto **ovos-spec-tools** (OpenVoiceOS/architecture#7).

## Changes

- `resource_files.py` — `locate_lang_directories`: `langcodes.tag_distance`
  → `ovos_spec_tools.lang_distance` (same `<10` threshold). `VocabularyFile` /
  `IntentFile` loading: `ovos_utils.bracket_expansion.expand_template` →
  `sorted(ovos_spec_tools.expand(...))`.
- `skills/converse.py` — `_get_closest_lang`: `langcodes.closest_match` +
  `standardize_lang_tag` + a manual threshold → `ovos_spec_tools.closest_lang`
  (standardizes and thresholds internally).
- `pyproject.toml` — adds `ovos-spec-tools>=0.0.1a2`.

All migrated symbols were internal imports — not re-exported — so no public
API changed and no deprecation shims were needed.

## Behaviour changes — conformance with OVOS-INTENT-1

- **Single-spacing fix**: the old `expand_template` left a double space when
  an optional segment was dropped (`hello [there] world` → `hello␣␣world`);
  the conformant expander yields `hello world`.
- A malformed template now raises `MalformedTemplate` instead of being
  silently expanded leniently (no fallback added).

## Deferred — follow-up (deliberately not done)

- `MustacheDialogRenderer` / `load_dialogs` still come from `ovos_utils.dialog`.
  `MustacheDialogRenderer` is part of the public `SkillResources` API (a
  property type and constructor argument); swapping it onto
  `ovos_spec_tools.DialogRenderer` risks the skill resource API and is left as
  a separate change.
- `standardize_lang_tag` in `converse.py` (message-language normalization,
  distinct from language *matching*) is left untouched.

## Verification

`test_resource_files.py` passes (28 tests). The migration touches three files
(`resource_files.py`, `converse.py`, `pyproject.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Legacy dialog renderer and several legacy resource classes are deprecated and now emit warnings.

* **Improvements**
  * Dialogs, intents and vocabularies use spec-based rendering/expansion for more consistent output.
  * Language matching for converse selection improved for better locale selection.
  * New runtime support for spec-based tooling.

* **Behavior changes**
  * Skill dialog rendering consolidated into a new render flow with consistent fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-workshop/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->