### PR TITLE
refactor: route OVOSSkill resource loading through ovos-spec-tools (back-compat)

### DIFF
--- a/docs/resource-files.md
+++ b/docs/resource-files.md
@@ -129,3 +129,22 @@ Optional file for homescreen integration. Placed at `locale/<lang>/skill.json`:
 ```
 
 These examples are emitted to the homescreen as `homescreen.register.examples` on skill startup.
+
+## Spec conformance — OVOS-INTENT-2
+
+Skill locale resource loading is delegated to `ovos_spec_tools.LocaleResources`.
+`OVOSSkill` builds one `LocaleResources` per resource root (cached on
+`_locale_resources` / `load_lang`) and uses it for dialog rendering
+(`render_dialog` → `ovos_spec_tools.render`), vocab lookup (`voc_match`,
+`voc_list` → `LocaleResources.voc_list`), and resource discovery
+(`find_resource` → `LocaleResources.find`). Language matching and template
+expansion come from the spec primitives (`closest_lang` / `standardize_lang`,
+`expand`).
+
+The legacy `SkillResources`, `ResourceFile`, `ResourceType`, and the related
+module-level helpers in `ovos_workshop/resource_files.py` are kept only as
+deprecated shims. The legacy `OVOSSkill` resource surface (`resources`,
+`dialog_renderer`, `find_resource`, …) is preserved on the
+`_LegacyResourcesMixin` deprecation mixin, which emits `@deprecated` warnings and
+forwards to the spec API. New code should construct `ovos_spec_tools.LocaleResources`
+directly.

--- a/ovos_workshop/app.py
+++ b/ovos_workshop/app.py
@@ -1,11 +1,10 @@
-from os.path import isdir, join
+from os.path import join
 from typing import Optional
 from ovos_config.locations import get_xdg_config_save_path
 from ovos_bus_client.util import get_mycroft_bus
-from ovos_utils.lang import standardize_lang_tag
+from ovos_spec_tools import find_lang_dir, standardize_lang
 from ovos_bus_client.apis.gui import GUIInterface
 from ovos_bus_client.client.client import MessageBusClient
-from ovos_workshop.resource_files import locate_lang_directories
 from ovos_workshop.skills.ovos import OVOSSkill
 
 
@@ -53,32 +52,19 @@ class OVOSAbstractApplication(OVOSSkill):
                          lang: Optional[str] = None) -> Optional[str]:
         """
         Get the best matched language resource directory for the requested lang.
-        This will consider dialects for the requested language, i.e. if lang is
-        set to pt-pt but only pt-br resources exist, the `pt-br` resource path
-        will be returned.
+
+        Delegates to :func:`ovos_spec_tools.find_lang_dir` — case mismatch
+        (``en-US`` vs ``en-us``), bare-language requests (``en`` against
+        ``en-US/``) and minor regional fallback (``en-au`` -> ``en-us``)
+        all resolve through one OVOS-INTENT-2 §2.2 predicate.
+
         @param base_path: root path to find resources (default res_dir)
         @param lang: language to get resources for (default self.lang)
         @return: path to language resources if they exist, else None
         """
-
-        base_path = base_path or self.res_dir
-        lang = lang or self.lang
-        lang = str(standardize_lang_tag(lang))
-
-        # base_path/lang-CODE (region is upper case)
-        if isdir(join(base_path, lang)):
-            return join(base_path, lang)
-        # base_path/lang-code (lowercase)
-        if isdir(join(base_path, lang.lower())):
-            return join(base_path, lang.lower())
-
-        # check for subdialects of same language as a fallback
-        # eg, language is set to en-au but only en-us resources are available
-        similar_dialect_directories = locate_lang_directories(lang, base_path)
-        for directory in similar_dialect_directories:
-            if directory.exists():
-                # NOTE: these are already sorted, the first is the best match
-                return str(directory)
+        resolved = find_lang_dir(base_path or self.res_dir,
+                                 standardize_lang(lang or self.lang))
+        return str(resolved) if resolved is not None else None
 
     def clear_intents(self):
         """

--- a/ovos_workshop/decorators/__init__.py
+++ b/ovos_workshop/decorators/__init__.py
@@ -79,7 +79,17 @@ def resting_screen_handler(name: str):
     Decorator for adding a method as a resting screen handler to optionally
     be shown on screen when device enters idle mode.
     @param name: Name of the restring screen to register
+
+    .. deprecated::
+        The resting-screen / homescreen concept is being deprecated entirely
+        and will be removed in a future release. No replacement is planned.
     """
+    import warnings
+    from ovos_utils.log import LOG
+    msg = ("@resting_screen_handler is deprecated; the resting-screen / "
+           "homescreen concept is being removed. No replacement is planned.")
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    LOG.warning(f"DEPRECATION: {msg}")
 
     def real_decorator(func):
         # Store the resting information inside the function
@@ -171,7 +181,17 @@ def homescreen_app(icon: str, name: Optional[str] = None):
 
     @param icon: icon file to use in app drawer (relative to "gui" folder)
     @param name: short name to show under the icon in app drawer
+
+    .. deprecated::
+        The homescreen concept is being deprecated entirely and will be
+        removed in a future release. No replacement is planned.
     """
+    import warnings
+    from ovos_utils.log import LOG
+    msg = ("@homescreen_app is deprecated; the homescreen concept is "
+           "being removed. No replacement is planned.")
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    LOG.warning(f"DEPRECATION: {msg}")
 
     def real_decorator(func):
         # Store the icon inside the function

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -12,22 +12,77 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Handling of skill data such as intents and regular expressions."""
+"""Handling of skill data such as intents and regular expressions.
+
+.. deprecated::
+    The whole :mod:`ovos_workshop.resource_files` module is deprecated and
+    will be removed in a future release. It predates the OVOS formal
+    specifications and is considered overengineered.
+
+    Use :mod:`ovos_spec_tools` instead:
+
+    * :class:`ovos_spec_tools.LocaleResources` replaces the resource loading
+      machinery (:class:`SkillResources`, :class:`ResourceFile` and friends).
+    * :func:`ovos_spec_tools.render` / :class:`ovos_spec_tools.DialogRenderer`
+      replace dialog rendering.
+    * :func:`ovos_spec_tools.expand` replaces template/variant expansion.
+    * :func:`ovos_spec_tools.closest_lang` / :func:`ovos_spec_tools.standardize_lang`
+      replace language matching.
+
+    The legacy resource types ``.qml``, ``.json``, ``.list``, ``.value``,
+    ``.rx`` (regex), ``.word`` and ``.template`` have no spec replacement;
+    they are legacy and not part of the OVOS formal specifications.
+
+    The module remains fully functional for downstream consumers; nothing has
+    been removed.
+"""
 import abc
 import json
 import re
+import warnings
+import functools
 from collections import namedtuple
 from os import walk
 from os.path import dirname
 from pathlib import Path
 from typing import List, Optional, Tuple, Dict, Any
 
-from langcodes import tag_distance
 from ovos_config.locations import get_xdg_data_save_path
+from ovos_spec_tools import expand, lang_distance, render as _spec_render
 from ovos_utils import flatten_list
 from ovos_spec_tools import expand, inline_keywords, MalformedTemplate
 from ovos_utils.dialog import MustacheDialogRenderer, load_dialogs
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
+
+from ovos_workshop.version import VERSION_MAJOR
+
+# removal version is computed from the current major, never hardcoded
+_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
+
+def _deprecated_public(msg: str):
+    """Decorator for public functions / ``__init__`` of public classes in this
+    module.
+
+    Combines the :func:`ovos_utils.log.deprecated` log notice with an inner
+    :class:`DeprecationWarning` (visible to IDEs/tooling). Always fires —
+    workshop's own internal code MUST NOT call these deprecated entry points,
+    so any warning surfaced is a real bug to fix at the call site, not
+    something to suppress by stack inspection.
+    """
+    _decorated = deprecated(msg, _REMOVAL_VERSION)
+
+    def wrapped(func):
+        logged = _decorated(func)
+
+        @functools.wraps(func)
+        def log_wrapper(*args, **kwargs):
+            warnings.warn(msg, DeprecationWarning, stacklevel=3)
+            return logged(*args, **kwargs)
+
+        return log_wrapper
+
+    return wrapped
 
 SkillResourceTypes = namedtuple(
     "SkillResourceTypes",
@@ -48,6 +103,9 @@ SkillResourceTypes = namedtuple(
 )
 
 
+@_deprecated_public(
+    "locate_base_directories is deprecated; use ovos_spec_tools.LocaleResources "
+    "for resource discovery.")
 def locate_base_directories(skill_directory: str,
                             resource_subdirectory: Optional[str] = None) -> \
         List[Path]:
@@ -56,6 +114,9 @@ def locate_base_directories(skill_directory: str,
     @param skill_directory: skill base directory to search for resources
     @param resource_subdirectory: optional extra resource directory to prepend
     @return: list of existing skill resource directories
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource discovery.
     """
     base_dirs = [Path(skill_directory, resource_subdirectory)] if \
         resource_subdirectory else []
@@ -67,6 +128,10 @@ def locate_base_directories(skill_directory: str,
     return candidates
 
 
+@_deprecated_public(
+    "locate_lang_directories is deprecated; use ovos_spec_tools.closest_lang / "
+    "standardize_lang for language matching and ovos_spec_tools.LocaleResources "
+    "for resource discovery.")
 def locate_lang_directories(lang: str, skill_directory: str,
                             resource_subdirectory: Optional[str] = None) -> List[Path]:
     """
@@ -76,6 +141,11 @@ def locate_lang_directories(lang: str, skill_directory: str,
     @param skill_directory: skill base directory to search for resources
     @param resource_subdirectory: optional extra resource directory to prepend
     @return: list of existing skill resource directories for the given lang
+
+    .. deprecated::
+        Use :func:`ovos_spec_tools.closest_lang` / :func:`ovos_spec_tools.standardize_lang`
+        for language matching and :class:`ovos_spec_tools.LocaleResources`
+        for resource discovery.
     """
     base_dirs = [Path(skill_directory, "locale")]
     if resource_subdirectory:
@@ -86,13 +156,11 @@ def locate_lang_directories(lang: str, skill_directory: str,
             for folder in directory.iterdir():
                 if folder.is_dir():
                     try:
-                        score = tag_distance(lang, folder.name)
+                        score = lang_distance(lang, folder.name)
                     except ValueError:  # not a valid language code
                         continue
-                    # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-                    # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-                    # 1- 3 -> These codes indicate a minor regional difference.
-                    # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
+                    # lang_distance follows the OVOS-LANG spec: 0 is identical,
+                    # a value of 10 or more is not a usable match.
                     if score < 10:
                         candidates.append((folder, score))
     # sort by distance to target lang code
@@ -100,10 +168,16 @@ def locate_lang_directories(lang: str, skill_directory: str,
     return [c[0] for c in candidates]
 
 
+@_deprecated_public(
+    "find_resource is deprecated; use ovos_spec_tools.LocaleResources for "
+    "resource discovery.")
 def find_resource(res_name: str, root_dir: str, res_dirname: str,
                   lang: Optional[str] = None) -> Optional[Path]:
     """
     Find a resource file.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource discovery.
 
     Searches for the given filename using this scheme:
         1. Search the resource lang directory:
@@ -155,8 +229,14 @@ class ResourceType:
         resource_type: one of a predefined set of resource types for skills
         file_extension: the file extension associated with the resource type
         base_directory: directory containing all files for the resource type
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource discovery.
     """
 
+    @_deprecated_public(
+        "ResourceType is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource discovery.")
     def __init__(self, resource_type: str, file_extension: str,
                  language: Optional[str] = None):
         self.resource_type = resource_type
@@ -273,8 +353,14 @@ class ResourceFile:
         resource_type: attributes of the resource type (dialog, vocab, etc.)
         resource_name: file name of the resource, with or without extension
         file_path: absolute path to the file
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading.
     """
 
+    @_deprecated_public(
+        "ResourceFile is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading.")
     def __init__(self, resource_type: ResourceType, resource_name: str):
         self.resource_type = resource_type
         self.resource_name = resource_name
@@ -346,6 +432,19 @@ class ResourceFile:
 
 
 class QmlFile(ResourceFile):
+    """Loads a ``.qml`` GUI resource file.
+
+    .. deprecated::
+        ``.qml`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "QmlFile is deprecated; .qml is a legacy resource type and is not part "
+        "of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
+
     def _locate(self):
         """ QML files are special because we do not want to walk the directory """
         file_path = None
@@ -378,6 +477,19 @@ class QmlFile(ResourceFile):
 
 
 class JsonFile(ResourceFile):
+    """Loads a ``.json`` resource file.
+
+    .. deprecated::
+        ``.json`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "JsonFile is deprecated; .json is a legacy resource type and is not "
+        "part of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
+
     def load(self) -> Dict[str, Any]:
         if self.file_path is not None:
             try:
@@ -389,8 +501,16 @@ class JsonFile(ResourceFile):
 
 
 class DialogFile(ResourceFile):
-    """Defines a dialog file, which is used instruct TTS what to speak."""
+    """Defines a dialog file, which is used instruct TTS what to speak.
 
+    .. deprecated::
+        Use :func:`ovos_spec_tools.render` / :class:`ovos_spec_tools.DialogRenderer`
+        for dialog rendering.
+    """
+
+    @_deprecated_public(
+        "DialogFile is deprecated; use ovos_spec_tools.render / "
+        "ovos_spec_tools.DialogRenderer for dialog rendering.")
     def __init__(self, resource_type, resource_name):
         super().__init__(resource_type, resource_name)
         self.data = None
@@ -416,20 +536,56 @@ class DialogFile(ResourceFile):
 
         return dialogs
 
-    def render(self, dialog_renderer):
-        """Renders a random phrase from a dialog file.
+    def _load_raw(self) -> List[str]:
+        """Load the phrase lines without expanding variants or filling slots.
 
-        If no file is found, the requested phrase is returned as the string. This
-        will use the default language for translations.
+        Slot filling and ``(a|b)``/``[x]`` expansion are deferred to
+        :func:`ovos_spec_tools.render`, which the spec defines as the
+        conformant renderer.
+        """
+        phrases = []
+        if self.file_path is not None:
+            for line in self._read():
+                phrases.append(line.replace("{{", "{").replace("}}", "}"))
+        return phrases
+
+    def render(self, dialog_renderer=None):
+        """Renders a random phrase from this dialog file.
+
+        Phrases are loaded from this file and rendered with
+        :func:`ovos_spec_tools.render`: ``(a|b)``/``[x]`` variants are expanded
+        and ``{name}`` slots are filled from ``self.data``.
+
+        Args:
+            dialog_renderer: unused, kept for backwards compatibility.
 
         Returns:
-            str: a randomized version of the phrase
+            str: a randomized, rendered version of the phrase
+
+        Raises:
+            FileNotFoundError: the ``.dialog`` resource does not exist or is
+                empty. A missing dialog is a skill bug — it is reported, not
+                silently rendered as the dialog name.
         """
-        return dialog_renderer.render(self.resource_name, self.data)
+        phrases = self._load_raw()
+        if not phrases:
+            raise FileNotFoundError(
+                f"missing or empty .dialog resource: {self.resource_name!r}")
+        return _spec_render(phrases, slots=self.data)
 
 
 class VocabularyFile(ResourceFile):
-    """Defines a vocabulary file, which skill use to form intents."""
+    """Defines a vocabulary file, which skill use to form intents.
+
+    .. deprecated::
+        Use :func:`ovos_spec_tools.expand` for vocabulary variant expansion.
+    """
+
+    @_deprecated_public(
+        "VocabularyFile is deprecated; use ovos_spec_tools.expand for "
+        "vocabulary variant expansion.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
 
     def load(self) -> List[List[str]]:
         """Loads a vocabulary file.
@@ -447,15 +603,22 @@ class VocabularyFile(ResourceFile):
         if self.file_path is not None:
             for line in self._read():
                 try:
-                    vocabulary.append(expand(line.lower()))
+                    vocabulary.append(sorted(expand(line.lower())))
                 except MalformedTemplate as err:
                     self._warn_malformed_line(line, err)
         return vocabulary
 
 
 class IntentFile(ResourceFile):
-    """Defines an intent file, which skill use to form intents."""
+    """Defines an intent file, which skill use to form intents.
 
+    .. deprecated::
+        Use :func:`ovos_spec_tools.expand` / :func:`ovos_spec_tools.render`.
+    """
+
+    @_deprecated_public(
+        "IntentFile is deprecated; use ovos_spec_tools.expand / "
+        "ovos_spec_tools.render.")
     def __init__(self, resource_type, resource_name):
         super().__init__(resource_type, resource_name)
         self.data = None
@@ -481,7 +644,7 @@ class IntentFile(ResourceFile):
                         # from the sibling vocabulary as an (a|b|c) group
                         # before expanding.
                         line = inline_keywords(line, self.vocabularies)
-                    intents.extend(flatten_list(expand(line)))
+                    intents.extend(flatten_list(sorted(expand(line))))
                 except MalformedTemplate as err:
                     self._warn_malformed_line(line, err)
             if not entities:
@@ -496,21 +659,44 @@ class IntentFile(ResourceFile):
                 intents = formatted
         return intents
 
-    def render(self, dialog_renderer):
-        """Renders a random phrase from a dialog file.
+    def render(self, dialog_renderer=None):
+        """Renders a random phrase from this intent file.
 
-        If no file is found, the requested phrase is returned as the string. This
-        will use the default language for translations.
+        Phrases are loaded from this file and rendered with
+        :func:`ovos_spec_tools.render`: ``(a|b)``/``[x]`` variants are expanded
+        and ``{name}`` slots are filled from ``self.data``.
+
+        Args:
+            dialog_renderer: unused, kept for backwards compatibility.
 
         Returns:
-            str: a randomized version of the phrase
+            str: a randomized, rendered version of the phrase
+
+        Raises:
+            FileNotFoundError: the ``.intent`` resource does not exist or is
+                empty.
         """
-        return dialog_renderer.render(self.resource_name, self.data)
+        phrases = []
+        if self.file_path is not None:
+            for line in self._read():
+                phrases.append(line.replace("{{", "{").replace("}}", "}"))
+        if not phrases:
+            raise FileNotFoundError(
+                f"missing or empty .intent resource: {self.resource_name!r}")
+        return _spec_render(phrases, slots=self.data)
 
 
 class NamedValueFile(ResourceFile):
-    """Defines a named value file, which maps a variable to a values."""
+    """Defines a named value file, which maps a variable to a values.
 
+    .. deprecated::
+        ``.value`` is a legacy resource type and is not part of the OVOS
+        formal specifications.
+    """
+
+    @_deprecated_public(
+        "NamedValueFile is deprecated; .value is a legacy resource type and is "
+        "not part of the OVOS formal specifications.")
     def __init__(self, resource_type, resource_name):
         super().__init__(resource_type, resource_name)
         self.delimiter = ","
@@ -551,14 +737,50 @@ class NamedValueFile(ResourceFile):
 
 
 class ListFile(DialogFile):
-    pass
+    """Defines a ``.list`` file.
+
+    .. deprecated::
+        ``.list`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "ListFile is deprecated; .list is a legacy resource type and is not "
+        "part of the OVOS formal specifications.")
+    def __init__(self, resource_type, resource_name):
+        super().__init__(resource_type, resource_name)
 
 
 class TemplateFile(DialogFile):
-    pass
+    """Defines a ``.template`` file.
+
+    .. deprecated::
+        ``.template`` is a legacy resource type and is not part of the OVOS
+        formal specifications; use :func:`ovos_spec_tools.expand`.
+    """
+
+    @_deprecated_public(
+        "TemplateFile is deprecated; .template is a legacy resource type and "
+        "is not part of the OVOS formal specifications; use "
+        "ovos_spec_tools.expand.")
+    def __init__(self, resource_type, resource_name):
+        super().__init__(resource_type, resource_name)
 
 
 class RegexFile(ResourceFile):
+    """Defines a ``.rx`` regex resource file.
+
+    .. deprecated::
+        ``.rx`` (regex) is a legacy resource type and is not part of the OVOS
+        formal specifications.
+    """
+
+    @_deprecated_public(
+        "RegexFile is deprecated; .rx (regex) is a legacy resource type and is "
+        "not part of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
+
     def load(self):
         regex_patterns = []
         if self.file_path:
@@ -568,7 +790,18 @@ class RegexFile(ResourceFile):
 
 
 class WordFile(ResourceFile):
-    """Defines a word file, which defines a word in the configured language."""
+    """Defines a word file, which defines a word in the configured language.
+
+    .. deprecated::
+        ``.word`` is a legacy resource type and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "WordFile is deprecated; .word is a legacy resource type and is not "
+        "part of the OVOS formal specifications.")
+    def __init__(self, resource_type: ResourceType, resource_name: str):
+        super().__init__(resource_type, resource_name)
 
     def load(self) -> Optional[str]:
         """Load and lines from a file and populate the variables.
@@ -619,6 +852,16 @@ class BlacklistFile(ResourceFile):
 
 
 class SkillResources:
+    """Loads and renders skill resource files.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading and
+        :func:`ovos_spec_tools.render` for dialog rendering.
+    """
+
+    @_deprecated_public(
+        "SkillResources is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading and ovos_spec_tools.render for dialog rendering.")
     def __init__(self, skill_directory: str,
                  language: str,
                  dialog_renderer: Optional[MustacheDialogRenderer] = None,
@@ -631,10 +874,21 @@ class SkillResources:
         self.static = dict()
 
     @property
+    @deprecated("dialog_renderer is deprecated; dialog rendering is handled by "
+                "ovos_spec_tools.render via SkillResources.render_dialog. "
+                "This compat shim will be removed.", _REMOVAL_VERSION)
     def dialog_renderer(self) -> MustacheDialogRenderer:
         """
         Get a dialog renderer object for these resources
+
+        Deprecated: dialog rendering is performed by
+        :func:`ovos_spec_tools.render` inside :meth:`render_dialog`. This
+        property is a compatibility shim that lazily builds a
+        :class:`MustacheDialogRenderer` for callers that expect one.
         """
+        warnings.warn(
+            "dialog_renderer is deprecated; use SkillResources.render_dialog",
+            DeprecationWarning, stacklevel=3)
         if not self._dialog_renderer:
             self._load_dialog_renderer()
         return self._dialog_renderer
@@ -649,6 +903,11 @@ class SkillResources:
     def _load_dialog_renderer(self):
         """
         Initialize a MustacheDialogRenderer object for these resources
+
+        Deprecated compat helper: loads ``.dialog`` files into a
+        :class:`MustacheDialogRenderer` for legacy callers of the
+        :attr:`dialog_renderer` property. New code renders via
+        :func:`ovos_spec_tools.render`.
         """
         # TODO: ovos_utils.dialog.load_dialogs/MustacheDialogRenderer are
         #  deprecated in favor of ovos_spec_tools.LocaleResources +
@@ -663,8 +922,11 @@ class SkillResources:
                                             "dialog")
         for directory in base_dirs:
             if directory.exists():
-                dialog_dir = str(directory)
-                self._dialog_renderer = load_dialogs(dialog_dir)
+                renderer = MustacheDialogRenderer()
+                for path in Path(directory).iterdir():
+                    if path.is_file() and path.suffix == ".dialog":
+                        renderer.load_template_file(path.stem, str(path))
+                self._dialog_renderer = renderer
                 return
         LOG.debug(f'No dialog loaded for {self.language}')
 
@@ -916,7 +1178,7 @@ class SkillResources:
         """
         resource_file = DialogFile(self.types.dialog, name)
         resource_file.data = data
-        return resource_file.render(self.dialog_renderer)
+        return resource_file.render()
 
     def load_skill_vocabulary(self, alphanumeric_skill_id: str) -> dict:
         """
@@ -1045,18 +1307,46 @@ class SkillResources:
 
 
 class CoreResources(SkillResources):
+    """Loads ovos-workshop's bundled core resources.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading.
+    """
+
+    @_deprecated_public(
+        "CoreResources is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading.")
     def __init__(self, language):
         directory = f"{dirname(__file__)}/locale"
         super().__init__(directory, language)
 
 
 class UserResources(SkillResources):
+    """Loads user-provided override resources.
+
+    .. deprecated::
+        Use :class:`ovos_spec_tools.LocaleResources` for resource loading.
+    """
+
+    @_deprecated_public(
+        "UserResources is deprecated; use ovos_spec_tools.LocaleResources for "
+        "resource loading.")
     def __init__(self, language, skill_id):
         directory = f"{get_xdg_data_save_path()}/resources/{skill_id}"
         super().__init__(directory, language)
 
 
 class RegexExtractor:
+    """Extracts a named group from an utterance using regex patterns.
+
+    .. deprecated::
+        :class:`RegexExtractor` is legacy and is not part of the OVOS formal
+        specifications.
+    """
+
+    @_deprecated_public(
+        "RegexExtractor is deprecated; it is legacy and is not part of the "
+        "OVOS formal specifications.")
     def __init__(self, group_name: str, regex_patterns: List[str]):
         """
         Init an object representing an entity and a list of possible regex

--- a/ovos_workshop/skills/_legacy_resources.py
+++ b/ovos_workshop/skills/_legacy_resources.py
@@ -1,0 +1,255 @@
+# Copyright 2026 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Deprecated resource-loading entry points for :class:`OVOSSkill`.
+
+OVOSSkill drives resource loading through
+:class:`ovos_spec_tools.LocaleResources`. These legacy entry points delegate
+to :class:`ovos_workshop.resource_files.SkillResources` and are isolated here
+so skills that still call them keep working.
+
+Surface that lives in the mixin:
+
+- :attr:`resources` — a :class:`SkillResources` handle;
+- :attr:`dialog_renderer` — a
+  :class:`~ovos_utils.dialog.MustacheDialogRenderer`;
+- :meth:`find_resource` — a :class:`SkillResources`-backed lookup;
+- :meth:`load_dialog_files` — no-op kept because some skill base classes
+  call it during boot;
+- :attr:`voc_match_cache` — accessor for the
+  :attr:`OVOSSkill._voc_cache` dict;
+- :attr:`runtime_requirements` / :attr:`network_requirements` — declared
+  deprecated in ovos-core; kept so LAN/cache/offline skills still load.
+
+The mixin assumes its host class supplies the attributes every OVOSSkill
+has: ``res_dir``, ``lang``, ``skill_id``, ``log``, and ``_voc_cache``. It
+owns one piece of state of its own — ``_skill_resources_compat`` — a
+single :class:`SkillResources` instance lazily built on first access and
+reused by every method below.
+"""
+from __future__ import annotations
+
+import warnings
+from typing import Dict, List, Optional
+
+from ovos_utils import classproperty
+from ovos_utils.log import LOG, deprecated
+from ovos_utils.process_utils import RuntimeRequirements
+from ovos_workshop.version import VERSION_MAJOR
+
+_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
+
+class _LegacyResourcesMixin:
+    """Deprecated resource API entry points on OVOSSkill.
+
+    Inheriting this mixin gives a skill the legacy entry points —
+    :attr:`resources`, :attr:`dialog_renderer`, :meth:`find_resource` — each
+    emitting a :class:`DeprecationWarning` pointing at the spec-tools-backed
+    replacement. The mixin holds one cached :class:`SkillResources` instance
+    so every legacy call routes through the same object.
+    """
+
+    # one cache per (res_dir, lang) for resources / dialog_renderer /
+    # find_resource. Keying on the resource language preserves
+    # back-compat for UniversalSkill (whose resources live in
+    # `internal_language` via `_resource_lang`) and for plain OVOSSkill
+    # instances whose session language can change at runtime.
+    def _legacy_skill_resources(self):
+        lang = getattr(self, "_resource_lang", None) or self.lang
+        key = (self.res_dir, lang)
+        cache = getattr(self, "_skill_resources_compat", None)
+        if not isinstance(cache, dict):
+            cache = {}
+            self._skill_resources_compat = cache
+        if key not in cache:
+            from ovos_workshop.resource_files import SkillResources
+            cache[key] = SkillResources(
+                self.res_dir, lang, skill_id=self.skill_id)
+        return cache[key]
+
+    def load_dialog_files(self, root_directory: Optional[str] = None):
+        """
+        Deprecated no-op kept for backwards compatibility.
+
+        ``.dialog`` files are loaded lazily by
+        :class:`~ovos_spec_tools.LocaleResources` when a dialog is rendered.
+        """
+
+    @property
+    @deprecated("self.resources is deprecated; use the high-level skill "
+                "methods (speak_dialog, register_intent_file, voc_match, "
+                "...) or construct ovos_spec_tools.LocaleResources directly",
+                f"{VERSION_MAJOR + 1}.0.0")
+    def resources(self):
+        """Back-compat handle returning a :class:`SkillResources`.
+
+        .. deprecated::
+            Returns a
+            :class:`ovos_workshop.resource_files.SkillResources`. The skill
+            framework routes through
+            :class:`ovos_spec_tools.LocaleResources`. This property keeps
+            code calling ``self.resources.load_*``,
+            ``self.resources.render_dialog`` etc. working. Migrate to the
+            high-level skill methods or construct
+            :class:`ovos_spec_tools.LocaleResources` directly.
+        """
+        # stacklevel=3: warn() -> body -> @deprecated wrapper -> caller
+        warnings.warn(
+            "self.resources is deprecated; use the high-level skill methods "
+            "or construct ovos_spec_tools.LocaleResources directly",
+            DeprecationWarning, stacklevel=3)
+        return self._legacy_skill_resources()
+
+    @property
+    @deprecated("dialog_renderer is deprecated; dialogs are rendered by "
+                "ovos_spec_tools.render via OVOSSkill.render_dialog. "
+                "This compat shim will be removed.",
+                f"{VERSION_MAJOR + 1}.0.0")
+    def dialog_renderer(self):
+        """Back-compat handle returning the legacy
+        :class:`~ovos_utils.dialog.MustacheDialogRenderer`.
+
+        .. deprecated::
+            Dialog rendering is performed by :func:`ovos_spec_tools.render`
+            via :meth:`render_dialog`. This property returns a real renderer
+            so skill code calling ``self.dialog_renderer.render(name, data)``
+            keeps working.
+        """
+        warnings.warn(
+            "dialog_renderer is deprecated; use OVOSSkill.render_dialog",
+            DeprecationWarning, stacklevel=3)
+        return self._legacy_skill_resources().dialog_renderer
+
+    @deprecated("find_resource is deprecated; use ovos_spec_tools.LocaleResources "
+                "for resource discovery", f"{VERSION_MAJOR + 1}.0.0")
+    def find_resource(self, res_name: str,
+                      res_dirname: Optional[str] = None,
+                      lang: Optional[str] = None) -> Optional[str]:
+        """Find a resource file (legacy).
+
+        .. deprecated::
+            Use :class:`ovos_spec_tools.LocaleResources` (or the high-level
+            skill methods) for resource discovery. This delegates to
+            :func:`ovos_workshop.resource_files.find_resource` for backward
+            compatibility with skills that still call it directly.
+        """
+        # stacklevel=3: warn() -> body -> @deprecated wrapper -> caller
+        warnings.warn(
+            "OVOSSkill.find_resource is deprecated; use "
+            "ovos_spec_tools.LocaleResources for resource discovery",
+            DeprecationWarning, stacklevel=3)
+        # import locally — the spec-tools-backed path doesn't touch this.
+        from ovos_spec_tools import standardize_lang
+        from ovos_workshop.resource_files import find_resource as _find
+        lang = standardize_lang(lang or self.lang)
+        x = _find(res_name, self.res_dir, res_dirname, lang)
+        if x:
+            return str(x)
+        self.log.error(f"Skill {self.skill_id} resource {res_name!r} for lang "
+                       f"{lang!r} not found in skill")
+        return None
+
+    @property
+    def voc_match_cache(self) -> Dict[str, List[str]]:
+        """Back-compat accessor for the per-skill vocab cache.
+
+        .. deprecated::
+            The cache is an internal detail; the public
+            :meth:`OVOSSkill.voc_list` / :meth:`OVOSSkill.voc_match` already
+            cache and reuse results. External callers should read or
+            invalidate via those methods, not this dict.
+        """
+        return self._voc_cache
+
+    @voc_match_cache.setter
+    @deprecated("OVOSSkill.voc_match_cache external mutation is deprecated; "
+                "use voc_list / voc_match instead", _REMOVAL_VERSION)
+    def voc_match_cache(self, val):
+        warnings.warn(
+            "OVOSSkill.voc_match_cache external mutation is deprecated; "
+            "use voc_list / voc_match instead",
+            DeprecationWarning, stacklevel=2)
+        if isinstance(val, dict):
+            self._voc_cache = val
+
+    @classproperty
+    def runtime_requirements(self) -> RuntimeRequirements:
+        """Declare what a skill expects to be available at init and at runtime.
+
+        .. deprecated::
+            Deprecated in ovos-core. Skills should let the framework infer
+            requirements from the intent surface; this hook stays around for
+            one release for the LAN/cache/offline-only skills that still
+            override it. Some examples that override it::
+
+                # IOT skill that scans the LAN on init
+                scans_on_init = True
+                RuntimeRequirements(internet_before_load=False,
+                                    network_before_load=scans_on_init,
+                                    requires_internet=False,
+                                    requires_network=True,
+                                    no_internet_fallback=True,
+                                    no_network_fallback=False)
+
+                # online search skill with a local cache
+                has_cache = False
+                RuntimeRequirements(internet_before_load=not has_cache,
+                                    network_before_load=not has_cache,
+                                    requires_internet=True,
+                                    requires_network=True,
+                                    no_internet_fallback=True,
+                                    no_network_fallback=True)
+
+                # a fully offline skill
+                RuntimeRequirements(internet_before_load=False,
+                                    network_before_load=False,
+                                    requires_internet=False,
+                                    requires_network=False,
+                                    no_internet_fallback=True,
+                                    no_network_fallback=True)
+        """
+        return RuntimeRequirements()
+
+    @classproperty
+    def network_requirements(self) -> RuntimeRequirements:
+        """Deprecated alias of :attr:`runtime_requirements`.
+
+        .. deprecated::
+            Kept so old skills still load. Override
+            :attr:`runtime_requirements` instead.
+        """
+        warnings.warn(
+            "network_requirements is deprecated; rename your override to "
+            "runtime_requirements.",
+            DeprecationWarning, stacklevel=2)
+        LOG.warning("network_requirements renamed to runtime_requirements, "
+                    "will be removed in ovos-core 0.0.8")
+        return self.runtime_requirements
+
+    # ----- homescreen concept (deprecated entirely, no replacement) -----
+    # The framework calls _register_homescreen_app / _register_resting_screen
+    # during _startup; these public shims keep external callers + subclass
+    # call-sites working and emit both a DeprecationWarning and a log line.
+    @deprecated("register_homescreen_app is deprecated; the homescreen "
+                "concept is being removed. No replacement is planned.",
+                _REMOVAL_VERSION)
+    def register_homescreen_app(self, icon: str, name: str, event: str):
+        """.. deprecated:: homescreen concept is being removed."""
+        warnings.warn(
+            "register_homescreen_app is deprecated; the homescreen concept "
+            "is being removed. No replacement is planned.",
+            DeprecationWarning, stacklevel=2)
+        return self._register_homescreen_app(icon, name, event)
+
+    @deprecated("register_resting_screen is deprecated; the resting-screen "
+                "/ homescreen concept is being removed. No replacement is "
+                "planned.", _REMOVAL_VERSION)
+    def register_resting_screen(self):
+        """.. deprecated:: resting-screen concept is being removed."""
+        warnings.warn(
+            "register_resting_screen is deprecated; the resting-screen / "
+            "homescreen concept is being removed. No replacement is planned.",
+            DeprecationWarning, stacklevel=2)
+        return self._register_resting_screen()

--- a/ovos_workshop/skills/auto_translatable.py
+++ b/ovos_workshop/skills/auto_translatable.py
@@ -3,7 +3,6 @@ from ovos_config import Configuration
 from ovos_bus_client import Message
 from ovos_utils.events import get_handler_name
 from ovos_utils.log import LOG
-from ovos_workshop.resource_files import SkillResources
 from ovos_workshop.skills.fallback import FallbackSkill
 from ovos_workshop.skills.ovos import OVOSSkill
 
@@ -60,18 +59,16 @@ class UniversalSkill(OVOSSkill):
                         f"internal_language, casting to {lang}")
             self.internal_language = lang
 
-    def _load_lang(self, root_directory=None, lang=None):
-        """
-        unlike base skill class all resources are in self.internal_language by
-        default instead of self.lang (which comes from message)
-        this ensures things like self.dialog_render reflect self.internal_lang
-        """
-        lang = lang or self.internal_language  # self.lang in base class
-        root_directory = root_directory or self.res_dir
-        if lang not in self._lang_resources:
-            self._lang_resources[lang] = SkillResources(root_directory, lang,
-                                                        skill_id=self.skill_id)
-        return self._lang_resources[lang]
+    @property
+    def _resource_lang(self) -> str:
+        """UniversalSkill authors its ``.dialog`` / ``.voc`` / ``.intent``
+        files in :attr:`internal_language`. Incoming utterances are
+        translated *into* that language before the handler runs and
+        :meth:`speak` translates outgoing text back to ``self.lang``, so
+        every resource lookup — dialog rendering, vocabulary listing and
+        matching, adapt keyword/regex registration — must target the
+        internal language regardless of the query language."""
+        return self.internal_language
 
     def detect_language(self, utterance: str):
         """
@@ -173,8 +170,9 @@ class UniversalSkill(OVOSSkill):
                 translation_data["translated"][key] = message.data[key] = \
                     _do_tx(message.data[key])
 
-        # special case
-        if self.translate_tags:
+        # special case — adapt entity captures land under ``__tags__``;
+        # other intent pipelines (padacioso, padatious, ...) do not
+        if self.translate_tags and "__tags__" in message.data:
             translation_data["original"]["__tags__"] = message.data["__tags__"]
             for idx, token in enumerate(message.data["__tags__"]):
                 message.data["__tags__"][idx] = \
@@ -298,7 +296,9 @@ class UniversalSkill(OVOSSkill):
                 "internal_lang": self.internal_language,
                 "target_lang": out_lang
             }
-            utterance = self.translate_utterance(utterance, sauce_lang, out_lang)
+            # translate_utterance(text, target_lang, sauce_lang): the
+            # outbound speak goes FROM internal TO user
+            utterance = self.translate_utterance(utterance, target_lang=out_lang, sauce_lang=sauce_lang)
             meta["translation_data"]["translated"] = utterance
             kwargs["meta"] = meta
         super().speak(utterance, *args, **kwargs)

--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -2,18 +2,16 @@ import abc
 from inspect import signature
 from typing import Optional
 
-from langcodes import closest_match
+from ovos_spec_tools import closest_lang, standardize_lang
 from ovos_bus_client.message import Message
 from ovos_bus_client.message import dig_for_message
 from ovos_config.config import Configuration
 from ovos_spec_tools import SpecMessage
-from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_utils.skills import get_non_properties
 from padacioso import IntentContainer
 
 from ovos_workshop.decorators.killable import AbortEvent, killable_event, AbortQuestion
-from ovos_workshop.resource_files import ResourceFile
 from ovos_workshop.skills.ovos import _core_owns_utterance_handled, OVOSSkill
 
 
@@ -88,12 +86,10 @@ class ConversationalSkill(OVOSSkill):
         for lang in self.native_langs:
             self.converse_matchers[lang] = IntentContainer(fuzz=fuzzy)
 
-            resources = self.load_lang(self.res_dir, lang)
-            resource_file = ResourceFile(resources.types.intent, intent_file)
-            if resource_file.file_path is None:
+            filename = self._locate_lang_file(intent_file, ".intent", lang)
+            if filename is None:
                 self.log.error(f'Unable to find "{intent_file}"')
                 continue
-            filename = str(resource_file.file_path)
 
             with open(filename) as f:
                 samples = [l.strip() for l in f.read().split("\n")
@@ -105,14 +101,9 @@ class ConversationalSkill(OVOSSkill):
 
     def _get_closest_lang(self, lang: str) -> Optional[str]:
         if self.converse_matchers:
-            lang = standardize_lang_tag(lang)
-            closest, score = closest_match(lang, list(self.converse_matchers.keys()))
-            # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-            # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-            # 1- 3 -> These codes indicate a minor regional difference.
-            # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
-            if score < 10:
-                return closest
+            # closest_lang follows the OVOS-LANG spec: it standardizes both
+            # sides and accepts a match only when the distance is below 10.
+            return closest_lang(lang, list(self.converse_matchers.keys()))
         return None
 
     def _handle_converse_ack(self, message: Message):
@@ -189,7 +180,7 @@ class ConversationalSkill(OVOSSkill):
                 params = signature(self.converse).parameters
                 kwargs = {"message": message,
                           "utterances": message.data['utterances'],
-                          "lang": standardize_lang_tag(message.data['lang'])}
+                          "lang": standardize_lang(message.data['lang'])}
                 kwargs = {k: v for k, v in kwargs.items() if k in params}
 
                 response_message.data["result"] = self.converse(**kwargs)

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -13,16 +13,17 @@
 # limitations under the License.
 import binascii
 import datetime
+import json
 import os
 import re
 import shutil
 import sys
 import time
 import traceback
+import warnings
 from copy import copy
 from hashlib import md5
 from inspect import signature
-from itertools import chain
 from os.path import join, abspath, dirname, basename, isfile
 from pathlib import Path
 from threading import Event, RLock
@@ -43,29 +44,31 @@ from ovos_spec_tools.resources import read_resource_file
 from ovos_config.config import Configuration
 from ovos_config.locations import get_xdg_cache_save_path
 from ovos_config.locations import get_xdg_config_save_path
+from ovos_config.locations import get_xdg_data_save_path
+from ovos_spec_tools import (LocaleResources, render, iter_locale_dirs,
+                              standardize_lang, strip_samples,
+                              utterance_contains)
 from ovos_number_parser import pronounce_number
 from ovos_option_matcher_fuzzy import FuzzyOptionMatcherPlugin
 from ovos_plugin_manager.agents import load_yesno_plugin, load_option_matcher_plugin
 from ovos_plugin_manager.language import OVOSLangTranslationFactory, OVOSLangDetectionFactory
 from ovos_plugin_manager.templates.agents import YesNoEngine, OptionMatcherEngine
-from ovos_utils import camel_case_split, classproperty
-from ovos_utils.dialog import MustacheDialogRenderer
+from ovos_utils import camel_case_split
 from ovos_utils.events import EventContainer, get_handler_name, create_wrapper
 from ovos_utils.file_utils import FileWatcher
 from ovos_utils.gui import get_ui_directories
 from ovos_utils.json_helper import merge_dict
 from ovos_utils.log import LOG
-from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap, RuntimeRequirements
+from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
 from ovos_utils.skills import get_non_properties
-from ovos_utils.text_utils import remove_accents_and_punct
 from ovos_yes_no import HeuristicYesNoEngine
 
 from ovos_workshop.decorators.killable import AbortEvent, killable_event, AbortQuestion
 from ovos_workshop.decorators.layers import IntentLayers
 from ovos_workshop.filesystem import FileSystemAccess
-from ovos_workshop.intents import IntentBuilder, Intent, IntentServiceInterface
-from ovos_workshop.resource_files import ResourceFile, find_resource, SkillResources
+from ovos_workshop.intents import IntentBuilder, Intent, munge_regex, munge_intent_parser, IntentServiceInterface
 from ovos_workshop.settings import PrivateSettings
+from ovos_workshop.skills._legacy_resources import _LegacyResourcesMixin
 from ovos_workshop.skills.util import join_word_list, simple_trace
 
 
@@ -80,7 +83,7 @@ def _core_owns_utterance_handled() -> bool:
     return OVOS_VERSION_TUPLE >= (2, 3, 0)
 
 
-class OVOSSkill:
+class OVOSSkill(_LegacyResourcesMixin):
     """
     Base class for OpenVoiceOS skills providing common behaviour and parameters
     to all Skill implementations.
@@ -123,6 +126,11 @@ class OVOSSkill:
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
         self.res_dir = resources_dir or self.root_dir
 
+        # per-root LocaleResources cache, lazily populated by load_lang
+        # so post-init res_dir mutations (legitimate for fixture-driven
+        # tests and live-reload skills) take effect on the next access.
+        self._lang_resources = {}
+
         self.gui = gui
         self._bus = bus
         self._enclosure = EnclosureAPI()
@@ -153,9 +161,6 @@ class OVOSSkill:
 
         # Cached voc file contents
         self._voc_cache = {}
-
-        # loaded lang file resources
-        self._lang_resources = {}
 
         # Delegator classes
         self.event_scheduler = EventSchedulerInterface()
@@ -212,43 +217,6 @@ class OVOSSkill:
         pass
 
     # skill class properties
-    @classproperty
-    def runtime_requirements(self) -> RuntimeRequirements:
-        """
-        Override to specify what a skill expects to be available at init and at
-        runtime. Default will assume network and internet are required and GUI
-        is not required for backwards-compat.
-
-        some examples:
-
-        IOT skill that controls skills via LAN could return:
-        scans_on_init = True
-        RuntimeRequirements(internet_before_load=False,
-                            network_before_load=scans_on_init,
-                            requires_internet=False,
-                            requires_network=True,
-                            no_internet_fallback=True,
-                            no_network_fallback=False)
-
-        online search skill with a local cache:
-        has_cache = False
-        RuntimeRequirements(internet_before_load=not has_cache,
-                            network_before_load=not has_cache,
-                            requires_internet=True,
-                            requires_network=True,
-                            no_internet_fallback=True,
-                            no_network_fallback=True)
-
-        a fully offline skill:
-        RuntimeRequirements(internet_before_load=False,
-                            network_before_load=False,
-                            requires_internet=False,
-                            requires_network=False,
-                            no_internet_fallback=True,
-                            no_network_fallback=True)
-        """
-        return RuntimeRequirements()
-
     @property
     def is_fully_initialized(self) -> bool:
         """
@@ -434,14 +402,29 @@ class OVOSSkill:
             raise TypeError(f"Expected a MessageBusClient, got: {type(value)}")
 
     # magic properties -> depend on message.context / Session
-    @property
-    def dialog_renderer(self) -> Optional[MustacheDialogRenderer]:
+    def render_dialog(self, name: str, data: Optional[dict] = None) -> str:
         """
-        Get a dialog renderer for this skill. Language will be determined by
-        message history to match the language associated with the current
-        session or else from Configuration.
+        Render a random phrase from a ``.dialog`` file for the skill's current
+        language, filling ``{name}`` slots from ``data``.
+
+        ``name`` may also be a **literal utterance** rather than a dialog key:
+        ``speak_dialog`` / ``get_response`` accept either form, so if no
+        ``.dialog`` resource matches, ``name`` is returned verbatim.
+
+        Args:
+            name: a dialog file name (no extension), or a literal utterance
+            data: values used to fill the dialog's named slots
+        Returns:
+            A rendered phrase ready for text-to-speech.
         """
-        return self.resources.dialog_renderer
+        lang = self._resource_lang
+        try:
+            phrases = self._locale_resources.load_dialog(name, lang)
+        except FileNotFoundError:
+            # `name` is not a dialog key — treat it as a literal utterance
+            return name
+        vocabularies = self._locale_resources.vocabularies(lang)
+        return render(phrases, slots=data, vocabularies=vocabularies)
 
     @property
     def system_unit(self) -> str:
@@ -512,6 +495,36 @@ class OVOSSkill:
         return standardize_lang(lang)
 
     @property
+    def _locale_resources(self) -> LocaleResources:
+        """Workshop-internal :class:`~ovos_spec_tools.LocaleResources` for
+        ``self.res_dir`` — the language-agnostic loader that backs every
+        per-language resource lookup on this skill.
+
+        Delegates to :meth:`load_lang` (which caches per root_directory)
+        so post-init changes to ``self.res_dir`` are picked up on the
+        next access. Workshop-internal code (``render_dialog``,
+        ``voc_match``, ``_locate_lang_file`` etc.) goes through this
+        attribute; the public, deprecated :attr:`resources` shim lives
+        on :class:`_LegacyResourcesMixin` and still hands back the
+        legacy :class:`SkillResources`.
+        """
+        return self.load_lang(self.res_dir)
+
+    @property
+    def _resource_lang(self) -> str:
+        """Language for resource-file lookups (``.dialog``, ``.voc``,
+        ``.intent``, ``.entity``).
+
+        Defaults to the message-context language (:attr:`lang`). Subclasses
+        that decouple resource language from query language — see
+        :class:`~ovos_workshop.skills.auto_translatable.UniversalSkill`,
+        whose dialogs/vocab are authored in ``internal_language`` while
+        ``self.lang`` reflects the incoming query language — override this
+        single property and the resource lookups follow.
+        """
+        return self.lang
+
+    @property
     def core_lang(self) -> str:
         """
         Get the configured default language as a BCP-47 language code.
@@ -540,118 +553,133 @@ class OVOSSkill:
                      if lang != self.core_lang] + [self.core_lang])
         return list(valid)
 
-    @property
-    def resources(self) -> SkillResources:
-        """
-        Get a SkillResources object for the current language. Objects are
-        initialized for the current language as needed.
-        """
-        return self.load_lang(self.res_dir, self.lang)
-
     # resource file loading
     def load_lang(self, root_directory: Optional[str] = None,
-                  lang: Optional[str] = None) -> SkillResources:
+                  lang: Optional[str] = None) -> LocaleResources:
         """
-        Get a SkillResources object for this skill in the requested `lang` for
-        resource files in the requested `root_directory`.
-        @param root_directory: root path to find resources (default res_dir)
-        @param lang: language to get resources for (default self.lang)
-        @return: SkillResources object
-        """
-        lang = standardize_lang(lang or self.lang)
-        root_directory = root_directory or self.res_dir
-        if lang not in self._lang_resources:
-            self._lang_resources[lang] = SkillResources(root_directory, lang,
-                                                        skill_id=self.skill_id)
-        return self._lang_resources[lang]
+        Get a :class:`~ovos_spec_tools.LocaleResources` object for this skill.
 
-    def load_dialog_files(self, root_directory: Optional[str] = None):
-        """
-        Load dialog files for all configured languages
-        @param root_directory: Directory to locate resources in
-            (default self.res_dir)
+        @param root_directory: skill root path containing ``locale/``
+            (default res_dir)
+        @param lang: unused, kept for backwards compatibility — language is
+            passed per ``load_*`` call.
+        @return: LocaleResources object
         """
         root_directory = root_directory or self.res_dir
-        # If "<skill>/dialog/<lang>" exists, load from there. Otherwise,
-        # load dialog from "<skill>/locale/<lang>"
-        for lang in self.native_langs:
-            resources = self.load_lang(root_directory, lang)
-            if resources.types.dialog.base_directory is None:
-                self.log.debug(f'No dialog loaded for {lang}')
+        if root_directory not in self._lang_resources:
+            workshop_locale = join(dirname(dirname(abspath(__file__))),
+                                   "locale")
+            user_locale = join(get_xdg_data_save_path(), "resources",
+                               self.skill_id) if self.skill_id else None
+            self._lang_resources[root_directory] = LocaleResources(
+                skill_locale=join(root_directory, "locale"),
+                core_locale=workshop_locale,
+                user_locale=user_locale)
+        return self._lang_resources[root_directory]
 
     def load_data_files(self, root_directory: Optional[str] = None):
         """
-        Called by the skill loader to load intents, dialogs, etc.
+        Called by the skill loader to load file-based vocabulary.
+
+        ``.dialog``/``.intent``/``.entity`` resources are loaded lazily by
+        :class:`~ovos_spec_tools.LocaleResources`; only ``.voc`` resources need
+        eager registration with the adapt intent service.
 
         Args:
             root_directory (str): root folder to use when loading files.
         """
         root_directory = root_directory or self.res_dir
-        self.load_dialog_files(root_directory)
         self.load_vocab_files(root_directory)
+        # legacy adapt-style regex resources; silent unless a .rx exists
         self.load_regex_files(root_directory)
 
     def load_vocab_files(self, root_directory: Optional[str] = None):
-        """ Load vocab files found under skill's root directory."""
-        root_directory = root_directory or self.res_dir
+        """Load ``.voc`` files under the skill's ``locale/`` directory and
+        register each template line as a single keyword with adapt — the
+        canonical entity comes first, aliases canonicalize to it
+        (OVOS-INTENT-2 §4.3 / :func:`ovos_spec_tools.keyword_form`)."""
+        resources = self.load_lang(root_directory or self.res_dir)
         for lang in self.native_langs:
-            resources = self.load_lang(root_directory, lang)
-            if resources.types.vocabulary.base_directory is None:
-                self.log.debug(f'No vocab loaded for {lang}')
-            else:
-                skill_vocabulary = resources.load_skill_vocabulary(
-                    self.alphanumeric_skill_id
-                )
-                # For each found intent register the default along with any aliases
-                for vocab_type in skill_vocabulary:
-                    for line in skill_vocabulary[vocab_type]:
-                        entity = line[0]
-                        aliases = line[1:]
-                        self.intent_service.register_keyword(
-                            vocab_type, entity, aliases, lang)
+            for voc_name, entity, aliases in resources.vocabulary_keywords(lang):
+                # keep exact filename case: str.title() lowercases multi-word
+                # CamelCase names ("HelloWorldKeyword" -> "Helloworldkeyword"),
+                # breaking IntentBuilder.require() lookups (#485/#491)
+                vocab_type = self.alphanumeric_skill_id + voc_name
+                self.intent_service.register_keyword(
+                    vocab_type, entity, aliases, lang)
 
     def load_regex_files(self, root_directory: Optional[str] = None) -> None:
-        """ Load regex files found under the skill directory."""
+        """Load and register ``.rx`` regex files for adapt-style intents.
+
+        Walks ``<root>/locale/<lang>/`` for ``.rx`` files; each non-blank,
+        non-``#``-comment line is one regex pattern. ``(?P<name>...)`` named
+        groups are prefixed with the skill's alphanumeric id so they don't
+        collide across skills. Each pattern is then registered with the adapt
+        intent service.
+
+        Self-contained — does NOT go through the deprecated
+        ``ovos_workshop.resource_files`` module. A ``DeprecationWarning`` is
+        emitted **only when a ``.rx`` file is actually loaded**, so skills that
+        ship none stay quiet.
+
+        .. deprecated::
+            For new intents that need pattern matching, prefer
+            **padatious-style template intents** with named ``{slots}`` — they
+            generalize, localize, and are part of the OVOS formal
+            specifications. ``.rx`` regex support remains for legacy adapt
+            skills; its deprecation is independent of (and outlives) the
+            broader ``resource_files`` deprecation, and its removal is not
+            yet scheduled.
+        """
         root_directory = root_directory or self.res_dir
-        for lang in self.native_langs:
-            resources = self.load_lang(root_directory, lang)
-            if resources.types.regex.base_directory is not None:
-                regexes = resources.load_skill_regex(self.alphanumeric_skill_id)
-                for regex in regexes:
-                    self.intent_service.register_adapt_regex(regex, lang)
+        unique_prefix = "(?P<" + self.alphanumeric_skill_id
+        loaded_any = False
+        # iter_locale_dirs walks `<root>/locale/` and filters subdirs against
+        # native_langs via closest_lang — so an `en-US/` tree is picked up for
+        # a skill that declares `en` (or `en-GB`) as native.
+        for lang_norm, locale_dir in iter_locale_dirs(
+                root_directory, native_langs=self.native_langs):
+            for directory, _, files in os.walk(locale_dir):
+                for file_name in files:
+                    if not file_name.endswith(".rx"):
+                        continue
+                    rx_path = join(directory, file_name)
+                    self.log.info(
+                        f"loading regex file {rx_path!r} for lang "
+                        f"{lang_norm!r}")
+                    with open(rx_path, "r", encoding="utf-8-sig") as f:
+                        for line in f:
+                            pattern = line.strip()
+                            if not pattern or pattern.startswith("#"):
+                                continue
+                            # uniqueify group names so they don't collide
+                            # across skills, then validate
+                            unique = unique_prefix.join(pattern.split("(?P<"))
+                            re.compile(unique)
+                            self.intent_service.register_adapt_regex(
+                                unique, lang_norm)
+                            loaded_any = True
+        if loaded_any:
+            msg = ("OVOSSkill.load_regex_files: .rx regex resources are "
+                   "deprecated. Prefer padatious-style template intents with "
+                   "named {slots} — they generalize, localize, and are part "
+                   "of the OVOS formal specifications. The .rx loader is kept "
+                   "for legacy adapt skills; consider migrating.")
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            LOG.warning(f"DEPRECATION: {msg}")
 
-    def find_resource(self, res_name: str, res_dirname: Optional[str] = None,
-                      lang: Optional[str] = None) -> Optional[str]:
+    def _locate_lang_file(self, name: str, ext: str,
+                          lang: str) -> Optional[str]:
+        """Resolve the on-disk path of a spec resource file.
+
+        Delegates to :meth:`ovos_spec_tools.LocaleResources.find` — the same
+        override-precedence + closest-language walk that backs every loader
+        call on this skill.
         """
-        Find a resource file.
-
-        Searches for the given filename using this scheme:
-            1. Search the resource lang directory:
-                <skill>/<res_dirname>/<lang>/<res_name>
-            2. Search the resource directory:
-                <skill>/<res_dirname>/<res_name>
-
-            3. Search the locale lang directory or other subdirectory:
-                <skill>/locale/<lang>/<res_name> or
-                <skill>/locale/<lang>/.../<res_name>
-
-        Args:
-            res_name (string): The resource name to be found
-            res_dirname (string, optional): A skill resource directory, such
-                                            'dialog', 'vocab', 'regex' or 'ui'.
-                                            Defaults to None.
-            lang (string, optional): language folder to be used.
-                                     Defaults to self.lang.
-
-        Returns:
-            string: The full path to the resource file or None if not found
-        """
-        lang = standardize_lang(lang or self.lang)
-        x = find_resource(res_name, self.res_dir, res_dirname, lang)
-        if x:
-            return str(x)
-        self.log.error(f"Skill {self.skill_id} resource '{res_name}' for lang "
-                       f"'{lang}' not found in skill")
+        if name.endswith(ext):
+            name = name[:-len(ext)]
+        path = self._locale_resources.find(name, ext, lang)
+        return str(path) if path is not None else None
 
     # skill object setup
     def _handle_first_run(self) -> None:
@@ -735,7 +763,7 @@ class OVOSSkill:
             self._register_skill_json()
             self._register_decorated()
             self._register_app_launcher()
-            self.register_resting_screen()
+            self._register_resting_screen()
 
             self.status.set_started()
             # run skill developer initialization code
@@ -756,11 +784,12 @@ class OVOSSkill:
         """Load skill.json metadata found under locale folder and register with homescreen"""
         root_directory = root_directory or self.res_dir
         for lang in self.native_langs:
-            resources = self.load_lang(root_directory, lang)
-            if resources.types.json.base_directory is None:
+            json_path = join(root_directory, "locale", lang, "skill.json")
+            if not isfile(json_path):
                 self.log.debug(f'No skill.json loaded for {lang}')
             else:
-                skill_meta = resources.load_json_file("skill.json")
+                with open(json_path) as f:
+                    skill_meta = json.load(f)
                 utts = skill_meta.get("examples", [])
                 if utts:
                     self.log.info(f"Registering example utterances with homescreen for lang: {lang} - {utts}")
@@ -777,9 +806,9 @@ class OVOSSkill:
                 icon = getattr(method, 'homescreen_app_icon')
                 name = name or self.__skill_id2name
                 LOG.debug(f"homescreen app registered: {name} - '{event}'")
-                self.register_homescreen_app(icon=icon,
-                                             name=name or self.skill_id,
-                                             event=event)
+                self._register_homescreen_app(icon=icon,
+                                              name=name or self.skill_id,
+                                              event=event)
                 self.add_event(event, method, speak_errors=False)
 
     @property
@@ -835,8 +864,17 @@ class OVOSSkill:
         self.gui = SkillGUI(self)
         self.gui.setup_default_handlers()
 
-    def register_homescreen_app(self, icon: str, name: str, event: str):
-        """the icon file MUST be located under 'gui' subfolder"""
+    def _register_homescreen_app(self, icon: str, name: str, event: str):
+        """Internal: register a homescreen app entry. Public-name shim
+        :meth:`register_homescreen_app` lives in :class:`_LegacyResourcesMixin`.
+        Reached only when a ``@homescreen_app``-tagged handler exists, so the
+        deprecation signal fires only for skills actually using the feature.
+        """
+        msg = ("homescreen apps are deprecated; the homescreen concept is "
+               "being removed and @homescreen_app / register_homescreen_app "
+               "will be dropped. No replacement is planned.")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        LOG.warning(f"DEPRECATION: {msg}")
         # this path is hardcoded in ovos_gui.constants and follows XDG spec
         # we use it to ensure resource availability between containers
         # it is the only path assured to be accessible both by skills and GUI
@@ -856,16 +894,26 @@ class OVOSSkill:
                                "name": name,
                                "event": event}))
 
-    def register_resting_screen(self):
-        """
-        Registers resting screen from the resting_screen_handler decorator.
+    def _register_resting_screen(self):
+        """Internal: scan for ``@resting_screen_handler``-tagged methods and
+        wire them up. Public-name shim :meth:`register_resting_screen` lives
+        in :class:`_LegacyResourcesMixin` and warns; this implementation
+        stays here because the framework calls it during ``_startup`` for
+        every skill — emitting on the internal path would flood the logs
+        of every skill, not just those using a resting screen.
 
-        This only allows one screen and if two is registered only one
-        will be used.
+        Only emits the per-handler log line when a tagged handler is found,
+        so skills not using the feature stay silent.
         """
         for attr_name in get_non_properties(self):
             handler = getattr(self, attr_name)
             if hasattr(handler, 'resting_handler'):
+                msg = ("resting screens are deprecated; the homescreen "
+                       "concept is being removed and @resting_screen_handler "
+                       "/ register_resting_screen will be dropped. No "
+                       "replacement is planned.")
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
+                LOG.warning(f"DEPRECATION: {msg}")
                 resting_name = handler.resting_handler
                 LOG.debug(f"{get_handler_name(handler)} is a resting screen, name: {resting_name}")
 
@@ -1326,12 +1374,10 @@ class OVOSSkill:
         """
         name = f'{self.skill_id}:{intent_file}'
         for lang in self.native_langs:
-            resources = self.load_lang(self.res_dir, lang)
-            resource_file = ResourceFile(resources.types.intent, intent_file)
-            if resource_file.file_path is None:
+            filename = self._locate_lang_file(intent_file, ".intent", lang)
+            if filename is None:
                 self.log.error(f'Unable to find "{intent_file}"')
                 continue
-            filename = str(resource_file.file_path)
 
             samples = read_resource_file(Path(filename))
 
@@ -1341,9 +1387,13 @@ class OVOSSkill:
 
             # OVOS-INTENT-2 §4.3: a sibling "<intent>.blacklist" locale file
             # lists slot-free phrases that should suppress this intent from
-            # matching
+            # matching. The file is optional — skip when absent.
             blacklist_name = intent_file.rsplit(".", 1)[0]
-            disallowed_strings += resources.load_blacklist_file(blacklist_name)
+            try:
+                disallowed_strings += self._locale_resources.load_blacklist(
+                    blacklist_name, lang)
+            except FileNotFoundError:
+                pass  # no sibling ".blacklist" file -> nothing to suppress
 
             # OVOS-INTENT-2 §4.3: for each "{slot}" the template declares, a
             # sibling "<slot>.blacklist" locale file lists slot-value
@@ -1354,7 +1404,10 @@ class OVOSSkill:
             with open(filename) as f:
                 slots = set(re.findall(r"{(.+?)}", f.read()))
             for slot in slots:
-                phrases = resources.load_blacklist_file(slot)
+                try:
+                    phrases = self._locale_resources.load_blacklist(slot, lang)
+                except FileNotFoundError:
+                    phrases = []
                 if phrases:
                     slot_blacklist[slot] = phrases
 
@@ -1365,7 +1418,7 @@ class OVOSSkill:
                 name, samples, lang,
                 blacklisted_words=disallowed_strings,
                 slot_blacklist=slot_blacklist,
-                vocabs=resources.vocabularies())
+                vocabs=self._locale_resources.vocabularies(lang))
         if handler:
             self.add_event(name, handler, 'mycroft.skill.handler',
                            activation=True, is_intent=True)
@@ -1401,12 +1454,10 @@ class OVOSSkill:
         if entity_file.endswith('.entity'):
             entity_file = entity_file.replace('.entity', '')
         for lang in self.native_langs:
-            resources = self.load_lang(self.res_dir, lang)
-            entity = ResourceFile(resources.types.entity, entity_file)
-            if entity.file_path is None:
+            filename = self._locate_lang_file(entity_file, ".entity", lang)
+            if filename is None:
                 self.log.error(f'Unable to find "{entity_file}"')
                 continue
-            filename = str(entity.file_path)
             name = f"{self.skill_id}:{basename(entity_file)}_" \
                    f"{md5(entity_file.encode('utf-8')).hexdigest()}"
             samples = read_resource_file(Path(filename))
@@ -1414,9 +1465,13 @@ class OVOSSkill:
             # lists slot-free phrases that MUST NOT fill the {slot} this entity
             # supplies (e.g. a "person.blacklist" of pronouns keeps "he" out of
             # the {person} slot)
-            blacklist = resources.load_blacklist_file(entity_file)
-            self.intent_service.register_entity(name, samples, lang,
-                                                blacklisted_words=blacklist)
+            try:
+                blacklist = self._locale_resources.load_blacklist(entity_file,
+                                                                  lang)
+            except FileNotFoundError:
+                blacklist = []
+            self.intent_service.register_padatious_entity(name, filename, lang,
+                                                          blacklist=blacklist)
 
     def register_vocabulary(self, entity: str, entity_type: str,
                             lang: Optional[str] = None):
@@ -1427,7 +1482,7 @@ class OVOSSkill:
         @param lang: language of `entity` (default self.lang)
         """
         keyword_type = self.alphanumeric_skill_id + entity_type
-        lang = standardize_lang(lang or self.lang)
+        lang = standardize_lang(lang or self._resource_lang)
         self.intent_service.register_keyword(keyword_type, entity,
                                              lang=lang)
 
@@ -1438,9 +1493,10 @@ class OVOSSkill:
         @param lang: language of regex_str (default self.lang)
         """
         self.log.debug('registering regex string: ' + regex_str)
-        re.compile(regex_str)  # validate regex
+        regex = munge_regex(regex_str, self.skill_id)
+        re.compile(regex)  # validate regex
         self.intent_service.register_adapt_regex(
-            regex_str, lang=standardize_lang(lang or self.lang))
+            regex, lang=standardize_lang(lang or self._resource_lang))
 
     # event/intent registering internal handlers
     def handle_homescreen_loaded(self, message: Message):
@@ -1552,8 +1608,9 @@ class OVOSSkill:
         # Convert "MyFancySkill" to "My Fancy Skill" for speaking
         handler_name = camel_case_split(self.name)
         msg_data = {'skill': handler_name}
-        lines = self.resources.load_dialog_file('skill.error', data=msg_data)
-        speech = lines[0] if lines else 'skill.error'
+        # render_dialog renders a phrase via ovos_spec_tools.render; if the
+        # `skill.error` dialog is missing, the key is returned verbatim.
+        speech = self.render_dialog('skill.error', msg_data)
         if speak_errors:
             self.speak(speech)
         self.log.exception(error)
@@ -1680,21 +1737,18 @@ class OVOSSkill:
                                                            modified string. 
                                                            Defaults to None.
         """
-        if self.dialog_renderer:
-            data = data or {}
-            utterance = self.dialog_renderer.render(key, data)
-            if render_callback is not None:
-                utterance = render_callback(utterance, self.lang)
-            self.speak(
-                utterance,
-                expect_response, wait, meta={'dialog': key, 'data': data}
-            )
-        else:
-            # TODO - change this behaviour, speaking the dialog file name isn't that helpful!
-            self.log.error(
-                'dialog_render is None, does the locale/dialog folder exist?'
-            )
-            self.speak(key, expect_response, wait, {})
+        data = data or {}
+        # render_dialog renders a phrase via ovos_spec_tools.render; `key` may
+        # also be a literal utterance — if no .dialog file matches it, it is
+        # spoken verbatim.
+        # TODO - change this behaviour, speaking the dialog file name isn't that helpful!
+        utterance = self.render_dialog(key, data)
+        if render_callback is not None:
+            utterance = render_callback(utterance, self.lang)
+        self.speak(
+            utterance,
+            expect_response, wait, meta={'dialog': key, 'data': data}
+        )
 
     def play_audio(self, filename: str, instant: bool = False,
                    wait: Union[bool, int] = False):
@@ -1837,14 +1891,13 @@ class OVOSSkill:
         def on_fail_default(utterance):
             fail_data = data.copy()
             fail_data['utterance'] = utterance
+            # render_dialog renders a phrase via ovos_spec_tools.render; a
+            # missing .dialog file falls back to the name with dots replaced
+            # by spaces.
             if on_fail:
-                if self.dialog_renderer:
-                    return self.dialog_renderer.render(on_fail, fail_data)
-                return on_fail
+                return self.render_dialog(on_fail, fail_data)
             else:
-                if self.dialog_renderer:
-                    return self.dialog_renderer.render(dialog, data)
-                return dialog
+                return self.render_dialog(dialog, data)
 
         def is_cancel(utterance):
             return self.voc_match(utterance, 'cancel', lang=session.lang)
@@ -2132,90 +2185,47 @@ class OVOSSkill:
 
     def voc_list(self, voc_filename: str,
                  lang: Optional[str] = None) -> List[str]:
+        """Cached per-skill view of a ``.voc`` phrase set.
+
+        Delegates the lookup to :meth:`LocaleResources.voc_list` (which
+        returns ``[]`` for a missing resource) and caches the result on
+        this skill instance so subsequent ``voc_match`` / ``remove_voc``
+        calls do not re-walk the locale tree.
         """
-        Get list of vocab options for the requested resource and cache the
-        results for future references.
-        @param voc_filename: Name of vocab resource to get options for
-        @param lang: language to get vocab for (default self.lang)
-        @return: list of string vocab options
-        """
-        lang = standardize_lang(lang or self.lang)
+        lang = standardize_lang(lang or self._resource_lang)
         cache_key = lang + voc_filename
-
         if cache_key not in self._voc_cache:
-            vocab = self.resources.load_vocabulary_file(voc_filename)
+            vocab = self._locale_resources.voc_list(voc_filename, lang)
             if vocab:
-                self._voc_cache[cache_key] = list(chain(*vocab))
-
+                self._voc_cache[cache_key] = list(vocab)
         return self._voc_cache.get(cache_key) or []
 
     def voc_match(self, utt: str, voc_filename: str, lang: Optional[str] = None,
                   exact: bool = False, ensure_ascii=True):
+        """Determine if ``utt`` matches any phrase from a ``.voc``.
+
+        By default (``exact=False``) a sample matches when it appears in the
+        utterance as a whole-word substring — so ``"yes, please"`` matches a
+        ``yes.voc`` of just ``yes``. With ``exact=True`` the utterance must
+        equal a sample after normalization.
+
+        ``ensure_ascii`` bundles the normalization knobs — it drops
+        diacritics and ASCII punctuation together; for finer control call
+        :func:`ovos_spec_tools.utterance_contains` directly with
+        ``strip_diacritics`` / ``strip_punct``.
         """
-        Determine if the given utterance contains the vocabulary provided.
-
-        By default the method checks if the utterance contains the given vocab
-        thereby allowing the user to say things like "yes, please" and still
-        match against "Yes.voc" containing only "yes". An exact match can be
-        requested.
-
-        The method first checks in the current Skill's .voc files and secondly
-        in the "locale" folder of ovos-workshop. The result is cached to
-        avoid hitting the disk each time the method is called.
-
-        Args:
-            utt (str): Utterance to be tested
-            voc_filename (str): Name of vocabulary file (e.g. 'cancel' for
-                                'locale/en-us/cancel.voc')
-            lang (str): Language code, defaults to self.lang
-            exact (bool): Whether the vocab must exactly match the utterance
-            ensure_ascii (bool): Whether to ignore accents and punctuation
-
-        Returns:
-            bool: True if the utterance has the given vocabulary it
-        """
-        lang = lang or self.lang
-        match = False
-        try:
-            _vocs = self.voc_list(voc_filename, lang)
-        except FileNotFoundError:
-            LOG.warning(
-                f"{self.skill_id} failed to find voc file '{voc_filename}' for lang '{lang}' in `{self.res_dir}'")
-            return False
-
-        if utt and _vocs:
-            if ensure_ascii:
-                utt = remove_accents_and_punct(utt)
-                _vocs = [remove_accents_and_punct(v) for v in _vocs]
-
-            if exact:
-                # Check for exact match
-                match = any(i.strip().lower() == utt.lower()
-                            for i in _vocs)
-            else:
-                # Check for matches against complete words
-                match = any([re.match(r'.*\b' + re.escape(i) + r'\b.*', utt, re.IGNORECASE)
-                             for i in _vocs])
-
-        return match
+        return utterance_contains(
+            utt, self.voc_list(voc_filename, lang), exact=exact,
+            strip_diacritics=ensure_ascii, strip_punct=ensure_ascii)
 
     def remove_voc(self, utt: str, voc_filename: str,
                    lang: Optional[str] = None) -> str:
-        """
-        Removes any vocab match from the utterance.
-        @param utt: Utterance to evaluate
-        @param voc_filename: vocab resource to remove from utt
-        @param lang: Optional language associated with vocab and utterance
-        @return: string with vocab removed
-        """
-        if utt:
-            # Check for matches against complete words
-            voc_list = self.voc_list(voc_filename, lang)
-            # From longest to shortest to replace composite terms first
-            for i in sorted(voc_list, key=len, reverse=True):
-                # Substitute only whole words matching the token
-                utt = re.sub(r'\b' + i + r'\b', '', utt)
-        return utt
+        """Return ``utt`` with every whole-word occurrence of any phrase from
+        a ``.voc`` removed (longest first so composite phrases consume their
+        parts)."""
+        if not utt:
+            return utt
+        return strip_samples(utt, self.voc_list(voc_filename, lang))
 
     # event related skill developer facing utils
     def add_event(self, name: str, handler: callable,
@@ -2536,27 +2546,6 @@ class OVOSSkill:
         # TODO: register TTS events to track state instead of guessing
         waiter.wait(0.5)  # if TTS had not yet started
         self.bus.emit(msg.forward("mycroft.audio.speech.stop"))
-
-    @classproperty
-    def network_requirements(self) -> RuntimeRequirements:
-        LOG.warning("network_requirements renamed to runtime_requirements, "
-                    "will be removed in ovos-core 0.0.8")
-        return self.runtime_requirements
-
-    @property
-    def voc_match_cache(self) -> Dict[str, List[str]]:
-        """
-        Backwards-compatible accessor method for vocab cache
-        @return: dict vocab resources to parsed resources
-        """
-        return self._voc_cache
-
-    @voc_match_cache.setter
-    def voc_match_cache(self, val):
-        self.log.warning("self._voc_cache should not be modified externally. This"
-                         "functionality will be deprecated in a future release")
-        if isinstance(val, dict):
-            self._voc_cache = val
 
 
 class SkillGUI(GUIInterface):

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -632,7 +632,6 @@ class OVOSSkill(_LegacyResourcesMixin):
             yet scheduled.
         """
         root_directory = root_directory or self.res_dir
-        unique_prefix = "(?P<" + self.alphanumeric_skill_id
         loaded_any = False
         # iter_locale_dirs walks `<root>/locale/` and filters subdirs against
         # native_langs via closest_lang — so an `en-US/` tree is picked up for
@@ -652,12 +651,14 @@ class OVOSSkill(_LegacyResourcesMixin):
                             pattern = line.strip()
                             if not pattern or pattern.startswith("#"):
                                 continue
-                            # uniqueify group names so they don't collide
-                            # across skills, then validate
-                            unique = unique_prefix.join(pattern.split("(?P<"))
-                            re.compile(unique)
+                            re.compile(pattern)  # validate before handing off
+                            # register_adapt_regex (IntentServiceInterface)
+                            # already prefixes "(?P<" group names with the
+                            # skill's alphanumeric id via munge_regex — do
+                            # not pre-munge here, it would double-prefix and
+                            # mismatch the keyword Adapt intents require()
                             self.intent_service.register_adapt_regex(
-                                unique, lang_norm)
+                                pattern, lang_norm)
                             loaded_any = True
         if loaded_any:
             msg = ("OVOSSkill.load_regex_files: .rx regex resources are "

--- a/ovos_workshop/skills/util.py
+++ b/ovos_workshop/skills/util.py
@@ -16,10 +16,38 @@ Utility functions for skills, including word list joining with language-specific
 and error traceback formatting.
 """
 
+import json
+import os
+from os.path import dirname, isdir, isfile, join
 from typing import Dict, List, Optional
 
+from ovos_spec_tools import closest_lang, iter_locale_dirs
 from ovos_utils.log import LOG
-from ovos_workshop.resource_files import CoreResources
+
+_LOCALE_ROOT = dirname(dirname(__file__))  # iter_locale_dirs looks for <root>/locale/
+
+
+def _load_workshop_json(name: str, lang: str) -> Optional[Dict]:
+    """Load a JSON config file shipped under ovos-workshop's ``locale/`` dir.
+
+    Resolves the closest available language directory per OVOS-LANG.
+
+    @param name: file base name (no extension)
+    @param lang: requested BCP-47 language tag
+    @return: parsed JSON dict, or None if not found
+    """
+    # discover available langs once, pick the single closest match
+    available = dict(iter_locale_dirs(_LOCALE_ROOT))  # {lang_norm: Path}
+    if not available:
+        return None
+    best = closest_lang(lang, list(available.keys()))
+    if best is None:
+        return None
+    path = join(str(available[best]), f"{name}.json")
+    if not isfile(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
 
 
 def simple_trace(stack_trace: List[str]) -> str:
@@ -50,7 +78,7 @@ def _get_word(lang: str, connector: str) -> str:
     Returns:
         Translated connector word, or ", " as fallback
     """
-    data = CoreResources(lang).load_json_file("word_connectors")
+    data = _load_workshop_json("word_connectors", lang) or {}
     if connector in data:
         return data[connector]
     LOG.warning(f"untranslated word connector '{connector}' for lang: {lang}")
@@ -67,7 +95,7 @@ def _load_euphony_rules(lang: str) -> Optional[Dict]:
         Dict with euphony rules or None if not found
     """
     try:
-        return CoreResources(lang).load_json_file("euphony")
+        return _load_workshop_json("euphony", lang)
     except Exception:
         return None
 

--- a/test/end2end/locale/en-US/drink.entity
+++ b/test/end2end/locale/en-US/drink.entity
@@ -1,0 +1,3 @@
+coffee
+tea
+juice

--- a/test/end2end/locale/en-US/greet.dialog
+++ b/test/end2end/locale/en-US/greet.dialog
@@ -1,0 +1,1 @@
+Hello {name}, <salutation>

--- a/test/end2end/locale/en-US/play.rx
+++ b/test/end2end/locale/en-US/play.rx
@@ -1,0 +1,1 @@
+play (?P<thing>.*) please

--- a/test/end2end/locale/en-US/salutation.voc
+++ b/test/end2end/locale/en-US/salutation.voc
@@ -1,0 +1,1 @@
+welcome aboard

--- a/test/end2end/locale/en-US/wave.intent
+++ b/test/end2end/locale/en-US/wave.intent
@@ -1,0 +1,4 @@
+wave at me
+wave hello
+wave goodbye
+say hi to me

--- a/test/end2end/locale/en-US/yes.voc
+++ b/test/end2end/locale/en-US/yes.voc
@@ -1,0 +1,5 @@
+yes
+yes please
+sure thing
+absolutely
+go ahead

--- a/test/end2end/test_padacioso_entity_file.py
+++ b/test/end2end/test_padacioso_entity_file.py
@@ -1,0 +1,103 @@
+# Copyright 2026 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""End-to-end ovoscope test: ``register_entity_file`` round-trips through
+the new ``_locate_lang_file`` resolver and reaches the bus as a
+``padatious:register_entity`` event with the resolved path and the
+parsed sample list.
+
+Companion to ``test_padacioso_intent_file.py``: same resolver, different
+file extension (``.entity`` vs ``.intent``). The fixture ships
+``locale/en-US/drink.entity`` with three sample values; the assertion
+is that the bus event carries the path of that file (proves
+``_locate_lang_file`` resolved the ``.entity`` correctly) and the
+parsed sample list (proves the OVOS-side entity-file reader can open
+and split it).
+
+**Note on what ``.entity`` does** — in OVOS, ``.entity`` files are
+hints / training samples for the intent engine, not strict slot
+constraints. An open ``{drink}`` slot would capture any token even
+without the entity file. This test therefore asserts on the
+*registration plumbing* rather than on slot-fill behaviour.
+"""
+from threading import Event
+from unittest import TestCase
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from ovos_workshop.skills.ovos import OVOSSkill
+
+ovoscope = pytest.importorskip("ovoscope")
+
+
+class _DrinkRegistrarSkill(OVOSSkill):
+    """Calls ``register_entity_file`` when poked via the bus, so the
+    test can subscribe to ``padatious:register_entity`` BEFORE the
+    registration fires."""
+
+    def initialize(self):
+        self.add_event("drinks.register", self._do_register)
+
+    def _do_register(self, _msg):
+        self.register_entity_file("drink.entity")
+
+
+class TestPadaciosoEntityFileE2E(TestCase):
+    """``register_entity_file`` -> ``_locate_lang_file(name, '.entity')``
+    -> ``intent_service.register_padatious_entity`` -> bus event
+    ``padatious:register_entity`` with the resolved file path and
+    parsed samples."""
+
+    def setUp(self):
+        self.skill_id = "drinks.openvoiceos"
+        self.minicroft = ovoscope.get_minicroft(
+            [self.skill_id],
+            extra_skills={self.skill_id: _DrinkRegistrarSkill},
+            lang="en-US")
+
+    def tearDown(self):
+        if self.minicroft is not None:
+            self.minicroft.stop()
+
+    def test_registration_resolves_entity_file_and_parses_samples(self):
+        registration = {}
+        registered = Event()
+
+        def _on_register(msg):
+            # Only react to our entity — other transformers / built-ins
+            # may register their own entities on the same bus event.
+            if msg.data.get("file_name", "").endswith("drink.entity"):
+                registration.update(msg.data)
+                registered.set()
+
+        self.minicroft.bus.on("padatious:register_entity", _on_register)
+
+        # Trigger registration AFTER subscribing.
+        session = Session("reg-1")
+        session.lang = "en-US"
+        self.minicroft.inject_message(Message(
+            "drinks.register", {},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"}))
+
+        self.assertTrue(
+            registered.wait(timeout=10),
+            "no ``padatious:register_entity`` bus event — "
+            "``register_entity_file`` did not resolve drink.entity "
+            "(``_locate_lang_file`` resolver may be broken for .entity)")
+        self.registration = registration
+
+        # The file_name in the event proves _locate_lang_file resolved
+        # the .entity file (not None, ends with the expected suffix).
+        file_name = self.registration.get("file_name", "")
+        self.assertTrue(
+            file_name.endswith("drink.entity"),
+            f"unexpected file_name in registration event: {file_name!r}")
+
+        # The parsed samples prove the OVOS-side entity reader opened
+        # the resolved path and split it correctly. Comments and blanks
+        # are filtered out by ``register_padatious_entity`` upstream.
+        samples = self.registration.get("samples", [])
+        self.assertEqual(sorted(samples), ["coffee", "juice", "tea"])

--- a/test/end2end/test_padacioso_intent_file.py
+++ b/test/end2end/test_padacioso_intent_file.py
@@ -1,0 +1,92 @@
+# Copyright 2026 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""End-to-end ovoscope test: ``register_intent_file`` round-trips through
+the new ``_locate_lang_file`` resolver and triggers an intent match.
+
+``OVOSSkill._locate_lang_file`` is the private helper introduced in PR #413
+that resolves ``<lang>/<name>.intent`` (and ``.entity``) under the skill's
+``locale/`` tree via :func:`ovos_spec_tools.closest_lang` + ``os.walk``.
+The resolved file path is then handed to whichever intent engine the
+pipeline runs — here padacioso, which is always available (pure Python,
+no native deps).
+
+The fixture ships ``locale/en-US/wave.intent`` with four utterance
+samples; sending ``wave hello`` should fire the registered handler.
+"""
+from threading import Event
+from unittest import TestCase
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from ovos_workshop.skills.ovos import OVOSSkill
+
+ovoscope = pytest.importorskip("ovoscope")
+
+
+class _WaveSkill(OVOSSkill):
+    """Registers ``wave.intent`` via ``register_intent_file`` and speaks
+    a confirmation on match."""
+
+    def initialize(self):
+        self.register_intent_file("wave.intent", self._on_wave)
+
+    def _on_wave(self, message):
+        self.speak("waving back")
+
+
+class TestPadaciosoIntentFileE2E(TestCase):
+    """``register_intent_file`` -> ``_locate_lang_file`` ->
+    padacioso registration -> bus match."""
+
+    def setUp(self):
+        self.skill_id = "wave.openvoiceos"
+        # padacioso-only pipeline so the test pins THIS path; if the
+        # intent doesn't match, the failure mode is unambiguous.
+        padacioso = ["ovos-padacioso-pipeline-plugin-high",
+                     "ovos-padacioso-pipeline-plugin-medium",
+                     "ovos-padacioso-pipeline-plugin-low"]
+        self.minicroft = ovoscope.get_minicroft(
+            [self.skill_id],
+            extra_skills={self.skill_id: _WaveSkill},
+            default_pipeline=padacioso,
+            lang="en-US")
+
+    def tearDown(self):
+        if self.minicroft is not None:
+            self.minicroft.stop()
+
+    def test_intent_file_match_fires_handler(self):
+        seen_speaks = []
+        speak_event = Event()
+
+        def on_speak(msg):
+            utt = msg.data.get("utterance", "")
+            seen_speaks.append(utt)
+            if "waving back" in utt:
+                speak_event.set()
+
+        self.minicroft.bus.on("speak", on_speak)
+
+        session = Session("wave-1")
+        session.lang = "en-US"
+        session.pipeline = ["ovos-padacioso-pipeline-plugin-high",
+                            "ovos-padacioso-pipeline-plugin-medium",
+                            "ovos-padacioso-pipeline-plugin-low"]
+        utterance = Message(
+            "recognizer_loop:utterance",
+            {"utterances": ["wave hello"], "lang": "en-US"},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"})
+        self.minicroft.inject_message(utterance)
+
+        self.assertTrue(
+            speak_event.wait(timeout=15),
+            "no speak message received — ``register_intent_file`` did not "
+            "register a matchable intent (``_locate_lang_file`` resolver "
+            "may be broken)")
+        self.assertTrue(
+            any("waving back" in s for s in seen_speaks),
+            f"expected `speak` with `waving back`; got: {seen_speaks}")

--- a/test/end2end/test_regex_skill.py
+++ b/test/end2end/test_regex_skill.py
@@ -1,0 +1,98 @@
+# Copyright 2026 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""End-to-end ovoscope test: a skill shipping a ``.rx`` regex file matches
+through Adapt and triggers its intent handler.
+
+This test is intentionally a **tripwire**. ``.rx`` / regex support is the one
+legacy resource type we kept (the rest were dropped in PR #413); when the time
+comes to actually remove regex support — separately from, and later than, the
+broader ``resource_files`` deprecation — this test breaks and forces us to
+pause before the change lands.
+"""
+from threading import Event
+from unittest import TestCase
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from ovos_workshop.intents import IntentBuilder
+from ovos_workshop.skills.ovos import OVOSSkill
+
+ovoscope = pytest.importorskip("ovoscope")
+
+
+class _RegexTestSkill(OVOSSkill):
+    """A test skill that ships ``test/end2end/locale/en-US/play.rx`` and
+    exposes an Adapt intent built on the regex's named ``thing`` group.
+
+    `OVOSSkill.root_dir` defaults to the directory of the module that defines
+    the class — `test/end2end/` here — so the fixture is found automatically
+    by `load_regex_files`.
+    """
+
+    def initialize(self):
+        # keyword name is the regex group name — `(?P...)` in the .rx file
+        intent = IntentBuilder("PlayIntent").require("thing").build()
+        self.register_intent(intent, self.handle_play)
+
+    def handle_play(self, message):
+        thing  = message.data.get("thing")
+        self.speak(f"playing {thing}")
+
+
+class TestRegexSkillE2E(TestCase):
+    """Regex-via-Adapt end-to-end tripwire."""
+
+    def setUp(self):
+        self.skill_id = "regextest.openvoiceos"
+        # adapt-only pipeline so this test actually exercises adapt's regex.
+        adapt_pipeline = ["ovos-adapt-pipeline-plugin-low"]
+        # Adapt's confidence for a regex-only intent with a single named group
+        # is low (~0.07 — adapt scales it by the entity count / utterance
+        # weight). Lower the per-tier thresholds so the low-tier still fires.
+        self.minicroft = ovoscope.get_minicroft(
+            [self.skill_id],
+            extra_skills={self.skill_id: _RegexTestSkill},
+            default_pipeline=adapt_pipeline,
+            lang="en-US",
+            pipeline_config={"ovos-adapt-pipeline-plugin": {"conf_low": 0.05}})
+
+    def tearDown(self):
+        if self.minicroft is not None:
+            self.minicroft.stop()
+
+    def test_regex_intent_fires_for_matching_utterance(self):
+        """`play music please` matches the .rx pattern, Adapt fires the
+        intent, the handler runs and emits a speak with the captured group."""
+        seen_speaks = []
+        speak_event = Event()
+
+        def on_speak(msg):
+            seen_speaks.append(msg.data.get("utterance", ""))
+            speak_event.set()
+
+        self.minicroft.bus.on("speak", on_speak)
+
+        session = Session("rxtest")
+        session.lang = "en-US"
+        # pin the per-session pipeline to adapt — the regex match is an Adapt
+        # feature, the default pipeline would also try padatious/fallback and
+        # we want a clean "if adapt doesn't fire, the test fails" assertion
+        session.pipeline = ["ovos-adapt-pipeline-plugin-low"]
+        utterance = Message(
+            "recognizer_loop:utterance",
+            {"utterances": ["play music please"], "lang": "en-US"},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"})
+        self.minicroft.inject_message(utterance)
+
+        # adapt + intent handler should run within a few seconds
+        self.assertTrue(
+            speak_event.wait(timeout=10),
+            "no speak message received — the .rx pattern did not produce an "
+            "intent match; regex support may be broken")
+        self.assertTrue(
+            any("playing music" in s for s in seen_speaks),
+            f"expected `speak` with the captured `music`; got: {seen_speaks}")

--- a/test/end2end/test_speak_dialog.py
+++ b/test/end2end/test_speak_dialog.py
@@ -1,0 +1,95 @@
+# Copyright 2026 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""End-to-end ovoscope test: ``speak_dialog`` rendering through the
+spec-tools-backed path.
+
+The new ``OVOSSkill.render_dialog`` resolves dialogs through
+:class:`ovos_spec_tools.LocaleResources.load_dialog` and renders via
+:func:`ovos_spec_tools.render`, threading the skill's vocabularies for
+``<voc>`` reference substitution. This is the bread-and-butter skill
+operation; silent breakage in the chain would render every dialog as
+the dialog *filename* rather than the dialog text.
+
+The fixture ships:
+
+- ``locale/en-US/greet.dialog`` — ``Hello {name}, <salutation>`` (a
+  slot and a vocab reference in one template).
+- ``locale/en-US/salutation.voc`` — single phrase ``welcome aboard``.
+
+A successful render produces ``Hello Alice, welcome aboard``.
+"""
+from threading import Event
+from unittest import TestCase
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from ovos_workshop.skills.ovos import OVOSSkill
+
+ovoscope = pytest.importorskip("ovoscope")
+
+
+class _GreeterSkill(OVOSSkill):
+    """Echoes the greeting back via ``speak_dialog`` when sent a
+    ``greeter.greet`` bus message."""
+
+    def initialize(self):
+        self.add_event("greeter.greet", self._on_greet)
+
+    def _on_greet(self, message):
+        self.speak_dialog("greet", data={"name": message.data.get("name", "")})
+
+
+class TestSpeakDialogE2E(TestCase):
+    """``speak_dialog`` -> ``render_dialog`` -> ``LocaleResources.load_dialog``
+    -> ``ovos_spec_tools.render`` -> bus ``speak`` message."""
+
+    def setUp(self):
+        self.skill_id = "greeter.openvoiceos"
+        self.minicroft = ovoscope.get_minicroft(
+            [self.skill_id],
+            extra_skills={self.skill_id: _GreeterSkill},
+            lang="en-US")
+
+    def tearDown(self):
+        if self.minicroft is not None:
+            self.minicroft.stop()
+
+    def test_speak_dialog_expands_slot_and_voc_reference(self):
+        seen_speaks = []
+        speak_event = Event()
+
+        def on_speak(msg):
+            utt = msg.data.get("utterance", "")
+            seen_speaks.append(utt)
+            # Gate the wait on the assertion target — protects against
+            # any unrelated bus traffic that happens to emit `speak`.
+            if "Alice" in utt:
+                speak_event.set()
+
+        self.minicroft.bus.on("speak", on_speak)
+
+        session = Session("greet-1")
+        session.lang = "en-US"
+        msg = Message(
+            "greeter.greet",
+            {"name": "Alice"},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"})
+        self.minicroft.inject_message(msg)
+
+        self.assertTrue(
+            speak_event.wait(timeout=10),
+            "no speak message received — speak_dialog/render_dialog chain "
+            "is broken")
+        # The {name} slot resolves to "Alice" and the <salutation> voc
+        # reference resolves to its single .voc entry.
+        self.assertTrue(
+            any("Alice" in s for s in seen_speaks),
+            f"slot ``{{name}}`` not substituted; got: {seen_speaks}")
+        self.assertTrue(
+            any("welcome aboard" in s for s in seen_speaks),
+            f"``<salutation>`` voc reference not resolved; got: "
+            f"{seen_speaks}")

--- a/test/end2end/test_universal_skill.py
+++ b/test/end2end/test_universal_skill.py
@@ -1,0 +1,298 @@
+# Copyright 2026 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""End-to-end ovoscope test: :class:`UniversalSkill` resource lookups
+follow ``internal_language``, not the incoming query language.
+
+The realistic motivating scenario is a skill backed by an English-only
+external API — Wolfram Alpha, animal facts, a weather provider — that an
+OVOS user can still address in any language. The skill author writes
+``.intent`` / ``.dialog`` / ``.voc`` files in English (``internal_language``);
+incoming utterances are translated *into* English before the handler runs,
+and outgoing speech is translated back to the user's language by
+:meth:`UniversalSkill.speak`.
+
+The lang-decoupling is the **defining behaviour** of UniversalSkill, and a
+regression would silently strand dialogs (skill speaks the literal dialog
+name) and break vocab checks. This module is a tripwire over the three
+public surfaces — :attr:`OVOSSkill._resource_lang`, :meth:`speak_dialog`,
+and :meth:`voc_match` — plus one full round-trip simulating the real-world
+flow with deterministic stubs (no network, no real translator plugin).
+"""
+import os
+from threading import Event
+from unittest import TestCase
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from ovos_workshop.skills.auto_translatable import UniversalSkill
+
+ovoscope = pytest.importorskip("ovoscope")
+
+# Each skill author writes resources in their working language; this skill
+# author writes English. Fixture tree shipped alongside the test module.
+_FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "universal_locale")
+
+
+# A small, deterministic, offline "translation table" stands in for the
+# real translator plugin: the test pins exact phrasing on both sides of
+# the boundary without needing network or a model. Keys are the source
+# string; ``(source_lang, target_lang)`` selects the direction.
+# Bidirectional, deterministic translation stub. UniversalSkill drives
+# translation **inside the skill** in both directions: the inbound handler
+# wrapper translates message slots into ``internal_language`` before the
+# callback runs, and :meth:`UniversalSkill.speak` translates outbound text
+# from ``internal_language`` to the user's session lang. The test pins
+# both legs.
+#
+# Keys are kept at the **primary subtag** so the lookup is stable across
+# ovos_bus_client versions (some versions fold the session lang through
+# ovos_utils.lang.standardize_lang_tag's macro=True default and deliver
+# "pt" rather than "pt-PT"). The stub's lookup folds to primary so the
+# test is not coupled to any particular bus-client behaviour.
+def _primary(tag):
+    return (tag or "").split("-", 1)[0].lower()
+
+
+_FAKE_TRANSLATIONS = {
+    # inbound: Portuguese → English (the user's slot lands here)
+    ("gatos", "pt", "en"): "cats",
+    # outbound: English → Portuguese (the skill's reply lands here)
+    ("Cats sleep up to sixteen hours a day.", "en", "pt"):
+        "Os gatos dormem até dezasseis horas por dia.",
+    ("I do not know about that animal.", "en", "pt"):
+        "Não conheço esse animal.",
+}
+
+
+class _AnimalFactsUniversalSkill(UniversalSkill):
+    """An English-only "animal facts" skill: API returns English; the
+    skill author wrote the .intent file in English; users may ask in any
+    language and get the reply in their own language."""
+
+    # Stand-in for the external API — a static dict keeps the test
+    # hermetic. A real skill would call out to Wolfram / a facts service.
+    _FAKE_API = {
+        "cat": "Cats sleep up to sixteen hours a day.",
+        "cats": "Cats sleep up to sixteen hours a day.",
+    }
+
+    def __init__(self, *args, **kwargs):
+        # resources_dir is honoured at __init__ time (before _startup
+        # runs initialize); pass it through so register_intent_file
+        # finds fact.intent in the fixture tree.
+        kwargs.setdefault("resources_dir", _FIXTURE_DIR)
+        # The handler reads a captured ``animal`` slot; tell
+        # translate_message to fold that key into internal_language too,
+        # alongside the default ``utterance`` / ``utterances`` keys.
+        kwargs.setdefault("translate_keys",
+                          ["animal", "utterance", "utterances"])
+        kwargs.setdefault("internal_language", "en-US")
+        super().__init__(*args, **kwargs)
+
+    # --- stubbed translation (no plugin, no network) ----------------------
+    #
+    # UniversalSkill drives translation inside the skill in both
+    # directions: translate_message folds incoming text to
+    # internal_language before the wrapped handler fires, and speak()
+    # translates outgoing text from internal_language to the user's
+    # session lang. Both legs route through translate_utterance, so the
+    # stub override is enough to control the whole table.
+
+    def translate_utterance(self, text, target_lang, sauce_lang=None):
+        sauce_lang = sauce_lang or self.internal_language
+        # exact-key lookup against the test's deterministic table; lang
+        # tags are folded to primary so the table works whether the
+        # runtime delivers "pt" or "pt-PT" (see _FAKE_TRANSLATIONS for
+        # the bus-client version note). Fall through to the source text
+        # so an untranslated branch surfaces in test failure output
+        # instead of silently no-oping.
+        key = (text, _primary(sauce_lang), _primary(target_lang))
+        return _FAKE_TRANSLATIONS.get(key, text)
+
+    # --- skill surface ----------------------------------------------------
+    def initialize(self):
+        self.register_intent_file("fact.intent", self.handle_fact)
+        # also expose direct event handlers for the two narrower
+        # tripwire assertions (no intent pipeline needed)
+        self.add_event("test.universal.voc_check", self.handle_voc_check)
+        self.add_event("test.universal.dialog_check", self.handle_dialog_check)
+
+    def handle_fact(self, message):
+        # The handler always receives the slot in ``internal_language``:
+        # UniversalSkill's universal_intent_handler wrapper ran
+        # translate_message on the way in, so a Portuguese "gatos" arrives
+        # here as "cats". The handler calls the English-only API directly
+        # and lets UniversalSkill.speak translate the reply back to the
+        # user's session lang on the way out.
+        animal = (message.data.get("animal") or "").lower().strip()
+        # record what the handler saw so the test can assert on the
+        # inbound translation as well as the outbound speak.
+        self._last_animal_seen = animal
+        fact = self._FAKE_API.get(animal, "I do not know about that animal.")
+        self.speak(fact)
+
+    def handle_voc_check(self, message):
+        # Pins that voc_match consults the en-US affirmative.voc even
+        # when the message's query lang is foreign.
+        utt = message.data.get("utt", "")
+        self.bus.emit(message.reply(
+            "test.universal.voc_check.response",
+            {"matched": self.voc_match(utt, "affirmative")}))
+
+    def handle_dialog_check(self, message):
+        # Pins that speak_dialog resolves the en-US echo.dialog
+        # regardless of session lang.
+        self.speak_dialog("echo", {"text": message.data.get("text", "")})
+
+
+class TestUniversalSkillResourceLang(TestCase):
+    """The three legs of the contract: the override returns the right
+    value, dialogs render from internal_language, voc_match queries
+    internal_language. Plus a real-world API round-trip."""
+
+    def setUp(self):
+        self.skill_id = "univtest.openvoiceos"
+        # A real-world UniversalSkill is addressed in multiple languages;
+        # padacioso registers its .intent for every entry in native_langs
+        # (= core_lang + secondary_langs). Configure the test env to
+        # include pt-PT so the pt-PT fact.intent gets registered and the
+        # full real-world round-trip is exercised — Portuguese utterance,
+        # English-only skill code, Portuguese reply.
+        self.minicroft = ovoscope.get_minicroft(
+            [self.skill_id],
+            extra_skills={self.skill_id: _AnimalFactsUniversalSkill},
+            lang="pt-PT",
+            secondary_langs=["en-US"])
+
+    def tearDown(self):
+        if self.minicroft is not None:
+            self.minicroft.stop()
+
+    def _skill(self):
+        return self.minicroft.plugin_skills[self.skill_id].instance
+
+    # --- the override itself ----------------------------------------------
+
+    def test_resource_lang_points_at_internal_language(self):
+        skill = self._skill()
+        self.assertEqual(skill._resource_lang, "en-US")
+        self.assertEqual(skill.internal_language, "en-US")
+
+    # --- dialog rendering follows internal_language -----------------------
+
+    def test_speak_dialog_renders_internal_lang_resource_for_foreign_query(self):
+        """A speak_dialog from a UniversalSkill handler renders the en-US
+        ``.dialog`` even when the message session lang is es-ES."""
+        spoken = []
+        event = Event()
+        self.minicroft.bus.on("speak", lambda m: (
+            spoken.append(m.data.get("utterance", "")), event.set()))
+
+        session = Session("uni-dialog")
+        session.lang = "es-ES"
+        self.minicroft.inject_message(Message(
+            "test.universal.dialog_check",
+            {"text": "world"},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"}))
+
+        self.assertTrue(event.wait(timeout=10),
+                        f"no speak within timeout; got {spoken!r}")
+        self.assertTrue(
+            any("world" in s for s in spoken),
+            f"expected dialog text 'world' in {spoken!r}")
+
+    # --- voc_match follows internal_language ------------------------------
+
+    def test_voc_match_uses_internal_language_for_foreign_query(self):
+        """voc_match("yes please", "affirmative") fires from a fr-FR session
+        because the voc is en-US and _resource_lang points there."""
+        responses = []
+        event = Event()
+        self.minicroft.bus.on(
+            "test.universal.voc_check.response",
+            lambda m: (responses.append(m.data.get("matched")), event.set()))
+
+        session = Session("uni-voc")
+        session.lang = "fr-FR"
+        self.minicroft.inject_message(Message(
+            "test.universal.voc_check",
+            {"utt": "yes, please"},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"}))
+
+        self.assertTrue(event.wait(timeout=10),
+                        "no voc_check response — handler did not fire")
+        self.assertEqual(
+            responses, [True],
+            "voc_match returned False — _resource_lang likely fell back to "
+            "the query lang (fr-FR) instead of internal_language (en-US)")
+
+    # --- realistic full round-trip ----------------------------------------
+
+    def test_realistic_pt_user_addresses_english_only_skill(self):
+        """Real round-trip: Portuguese-speaking user, English-only skill code.
+
+        The skill ships a Portuguese ``fact.intent`` (a real-world skill
+        would ship one per supported language); padacioso matches it
+        against a real ``recognizer_loop:utterance`` in Portuguese and
+        captures ``animal="gatos"``. The :class:`UniversalSkill`
+        handler-wrapper folds that slot into ``internal_language``
+        before the callback runs, so the user's skill code is
+        single-language: hits an English-only API with ``"cats"``, gets
+        an English fact, calls ``self.speak(fact)``. :meth:`speak`
+        translates the reply back to Portuguese on the way out — the
+        user never sees the English internals.
+
+        Three failure modes this catches:
+
+        * pt-PT ``.intent`` not registered → padacioso never matches,
+          no speak fires;
+        * inbound translation skipped → handler sees ``"gatos"`` instead
+          of ``"cats"``, API lookup misses, user gets the fallback;
+        * outbound translation skipped or argument-swapped → user
+          gets the English fact verbatim instead of the translation.
+        """
+        spoken = []
+        event = Event()
+        self.minicroft.bus.on("speak", lambda m: (
+            spoken.append(m.data.get("utterance", "")), event.set()))
+
+        # A real Portuguese utterance from the user. Padacioso (bundled,
+        # always available in the test env) matches the pt-PT intent
+        # file the skill ships and captures the animal slot in Portuguese.
+        session = Session("uni-roundtrip")
+        session.lang = "pt-PT"
+        self.minicroft.inject_message(Message(
+            "recognizer_loop:utterance",
+            {"utterances": ["conta-me um facto sobre gatos"],
+             "lang": "pt-PT"},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"}))
+
+        self.assertTrue(
+            event.wait(timeout=10),
+            "no speak within 10s — the pt-PT fact.intent likely never "
+            f"matched. spoken={spoken!r}")
+
+        # Inbound translation happened inside the skill: the handler
+        # received the slot already in internal_language.
+        skill = self._skill()
+        self.assertEqual(
+            getattr(skill, "_last_animal_seen", None), "cats",
+            "handler saw the Portuguese slot 'gatos' — the inbound "
+            "translate_message step in the universal_intent_handler "
+            "wrapper did not run, or was bypassed.")
+
+        # Outbound translation happened inside speak(): the user gets
+        # Portuguese, never sees the English internals.
+        self.assertTrue(
+            any("dezasseis" in s for s in spoken),
+            "expected the Portuguese translation of the English API "
+            f"reply in the speak utterance; got {spoken!r}. "
+            "UniversalSkill.speak may have skipped the outbound "
+            "translation step, or its translate_utterance arguments "
+            "are still source/target-swapped.")

--- a/test/end2end/test_universal_skill.py
+++ b/test/end2end/test_universal_skill.py
@@ -274,8 +274,12 @@ class TestUniversalSkillResourceLang(TestCase):
                      "source": "A", "destination": "B"}))
 
         self.assertTrue(
-            event.wait(timeout=10),
-            "no speak within 10s — the pt-PT fact.intent likely never "
+            # padatious/padacioso training for two langs (pt-PT + en-US)
+            # under full-suite load can take longer than 10s; 15s matches
+            # the timeout used for the other padacioso e2e round-trip
+            # (test_padacioso_intent_file.py)
+            event.wait(timeout=15),
+            "no speak within 15s — the pt-PT fact.intent likely never "
             f"matched. spoken={spoken!r}")
 
         # Inbound translation happened inside the skill: the handler

--- a/test/end2end/test_voc_match.py
+++ b/test/end2end/test_voc_match.py
@@ -1,0 +1,88 @@
+# Copyright 2026 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""End-to-end ovoscope test: ``voc_match`` on a plain ``OVOSSkill``
+loads ``.voc`` phrases through ``LocaleResources.load_vocabulary``,
+caches them in ``_voc_cache``, and matches utterances.
+
+``voc_match`` / ``voc_list`` are the workhorse skill-side helpers for
+keyword detection (used by stop / cancel / confirmation flows across
+the ecosystem). They were rewired off ``SkillResources`` onto
+``LocaleResources`` in PR #413; a silent regression would make every
+keyword check return ``False`` and break those flows.
+
+The fixture ships ``locale/en-US/yes.voc`` with five affirmative
+phrases. The skill exposes a bus handler that calls ``self.voc_match``
+on the inbound text and echoes the boolean result back, so the test
+can assert both the True case (``"sure thing"``) and the False case
+(``"no idea"``) deterministically.
+"""
+from threading import Event
+from unittest import TestCase
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from ovos_workshop.skills.ovos import OVOSSkill
+
+ovoscope = pytest.importorskip("ovoscope")
+
+
+class _AffirmativeSkill(OVOSSkill):
+
+    def initialize(self):
+        self.add_event("affirm.check", self._on_check)
+
+    def _on_check(self, message):
+        utt = message.data.get("utterance", "")
+        self.bus.emit(message.reply("affirm.result",
+                                    {"matched": self.voc_match(utt, "yes")}))
+
+
+class TestVocMatchE2E(TestCase):
+    """``voc_match`` -> ``voc_list`` -> ``LocaleResources.load_vocabulary``
+    -> ``_voc_cache`` -> bus reply."""
+
+    def setUp(self):
+        self.skill_id = "affirm.openvoiceos"
+        self.minicroft = ovoscope.get_minicroft(
+            [self.skill_id],
+            extra_skills={self.skill_id: _AffirmativeSkill},
+            lang="en-US")
+
+    def tearDown(self):
+        if self.minicroft is not None:
+            self.minicroft.stop()
+
+    def _ask(self, utterance: str) -> bool:
+        reply = {}
+        got = Event()
+
+        def on_result(msg):
+            reply["matched"] = msg.data.get("matched")
+            got.set()
+
+        self.minicroft.bus.on("affirm.result", on_result)
+
+        session = Session("voc-1")
+        session.lang = "en-US"
+        self.minicroft.inject_message(Message(
+            "affirm.check",
+            {"utterance": utterance},
+            context={"session": session.serialize(),
+                     "source": "A", "destination": "B"}))
+        self.assertTrue(got.wait(timeout=10),
+                        f"no affirm.result for {utterance!r}")
+        return reply["matched"]
+
+    def test_phrase_in_voc_file_matches(self):
+        self.assertTrue(self._ask("sure thing"),
+                        "voc_match returned False for an in-vocabulary "
+                        "phrase — LocaleResources.load_vocabulary may have "
+                        "returned an empty list")
+
+    def test_phrase_not_in_voc_file_does_not_match(self):
+        self.assertFalse(self._ask("no idea"),
+                         "voc_match returned True for an out-of-vocabulary "
+                         "phrase")

--- a/test/end2end/universal_locale/locale/en-US/affirmative.voc
+++ b/test/end2end/universal_locale/locale/en-US/affirmative.voc
@@ -1,0 +1,1 @@
+(yes|yeah|yep)

--- a/test/end2end/universal_locale/locale/en-US/echo.dialog
+++ b/test/end2end/universal_locale/locale/en-US/echo.dialog
@@ -1,0 +1,1 @@
+echo: {text}

--- a/test/end2end/universal_locale/locale/en-US/fact.intent
+++ b/test/end2end/universal_locale/locale/en-US/fact.intent
@@ -1,0 +1,2 @@
+tell me a fact about {animal}
+what about {animal}

--- a/test/end2end/universal_locale/locale/pt-PT/fact.intent
+++ b/test/end2end/universal_locale/locale/pt-PT/fact.intent
@@ -1,0 +1,2 @@
+conta-me um facto sobre {animal}
+o que sabes sobre {animal}

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -570,33 +570,27 @@ class TestOVOSSkill(unittest.TestCase):
         skill.res_dir = join(dirname(__file__), "test_locale")
         en_file = join(skill.res_dir, "locale", "en-US", "dow.entity")
         uk_file = join(skill.res_dir, "locale", "uk-UA", "dow.entity")
-        with open(en_file) as f:
-            en_samples = f.read().split("\n")
-        with open(uk_file) as f:
-            uk_samples = f.read().split("\n")
-        en_samples = [_ for _ in en_samples if _ and not _.startswith("#")]
-        uk_samples = [_ for _ in uk_samples if _ and not _.startswith("#")]
 
         # No secondary languages
         skill.config_core["lang"] = "en-US"
         skill.config_core["secondary_langs"] = []
         skill.register_entity_file("dow")
-        skill.intent_service.register_entity.assert_called_once_with(
+        skill.intent_service.register_padatious_entity.assert_called_once_with(
             f"{skill.skill_id}:dow_d446b2a6e46e7d94cdf7787e21050ff9",
-            en_samples, "en-US", blacklisted_words=[])
+            en_file, "en-US", blacklist=[])
 
         # With secondary language
-        skill.intent_service.register_entity.reset_mock()
+        skill.intent_service.register_padatious_entity.reset_mock()
         skill.config_core["secondary_langs"] = ["en-US", "uk-UA"]
         skill.register_entity_file("dow")
         self.assertEqual(
-            skill.intent_service.register_entity.call_count, 2)
-        skill.intent_service.register_entity.assert_any_call(
+            skill.intent_service.register_padatious_entity.call_count, 2)
+        skill.intent_service.register_padatious_entity.assert_any_call(
             f"{skill.skill_id}:dow_d446b2a6e46e7d94cdf7787e21050ff9",
-            en_samples, "en-US", blacklisted_words=[])
-        skill.intent_service.register_entity.assert_any_call(
+            en_file, "en-US", blacklist=[])
+        skill.intent_service.register_padatious_entity.assert_any_call(
             f"{skill.skill_id}:dow_d446b2a6e46e7d94cdf7787e21050ff9",
-            uk_samples, "uk-UA", blacklisted_words=[])
+            uk_file, "uk-UA", blacklist=[])
 
     def test_handle_enable_intent(self):
         # TODO


### PR DESCRIPTION
Supersedes #413 (closed during squash). Part of the OVOS migration onto [ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools) ([architecture#7](https://github.com/OpenVoiceOS/architecture/issues/7)).

`OVOSSkill` and the rest of `ovos_workshop` now route resource access through `ovos_spec_tools.LocaleResources` directly. The legacy `ovos_workshop.resource_files.SkillResources` is no longer used **internally** but stays shipped and stays available on every `OVOSSkill` through a deprecation mixin — every skill in the ecosystem keeps working.

## Back-compat surface preserved

All legacy entry points stay on `OVOSSkill` via the new [`_LegacyResourcesMixin`](https://github.com/OpenVoiceOS/ovos-workshop/blob/feat/drop-resource-files-usage/ovos_workshop/skills/_legacy_resources.py). Each emits a single `DeprecationWarning` and routes through the same cached `SkillResources` instance so behaviour is unchanged.

| Legacy member | Behaviour | Migration |
|---|---|---|
| `self.resources` | Real `SkillResources`. `self.resources.load_dialog` / `render_dialog` / `load_vocab` / `load_list_file` / `.value` / `.template` / `.word` / `.json` all keep working. | High-level methods (`speak_dialog`, `voc_match`, …) or `ovos_spec_tools.LocaleResources` directly. |
| `self.dialog_renderer` | Real `MustacheDialogRenderer`. `render(name, data)` works unchanged. | `OVOSSkill.render_dialog` (delegates to `ovos_spec_tools.render`). |
| `self.find_resource(name, dirname=None, lang=None)` | Delegates to `ovos_workshop.resource_files.find_resource`. | `ovos_spec_tools.LocaleResources.find`. |
| `self.load_dialog_files(root=None)` | Silent no-op shim. | Drop the call (`LocaleResources` is lazy). |
| `self.voc_match_cache` | Live `_voc_cache` getter; setter emits warning + accepts dict. | `voc_match` / `voc_list` cache internally. |
| `runtime_requirements` / `network_requirements` | `classproperty` shims; subclass overrides honoured. | Let the framework infer from the intent surface. |

The mixin is a single `import` away from removal — when the deprecation window closes, dropping `_LegacyResourcesMixin` from `OVOSSkill`'s bases (and deleting `_legacy_resources.py`) is the only change needed.

Other resource roles outside OVOS-INTENT-2 (`.list`, `.value`, `.word`, `.template`, `.qml`, skill-side `.json`) keep loading through the preserved `self.resources` handle.

## What changed internally (no public-surface impact)

- **`.dialog`** -> `LocaleResources.load_dialog` + `ovos_spec_tools.render` with `vocabularies()` for `<voc>` references. Drives `render_dialog`, `speak_dialog`, `get_response`, the `skill.error` flow.
- **`.voc`** -> `LocaleResources.vocabularies()` (eager Adapt-keyword registration) and `load_vocabulary` (for `voc_list` / `voc_match` / `remove_voc`).
- **`.intent` / `.entity`** -> `OVOSSkill._locate_lang_file` (closest_lang + os.walk); resolved path handed to `intent_service.register_padatious_{intent,entity}`.
- **`.rx`** regex files -> `OVOSSkill.load_regex_files` is kept and self-contained; deprecation independent of (and outliving) the broader `resource_files` deprecation.
- **Language directory resolution** in `OVOSAbstractApplication.get_language_dir` delegates to [`ovos_spec_tools.find_lang_dir`](https://github.com/OpenVoiceOS/ovos-spec-tools/pull/17) (new public helper in ovos-spec-tools 0.6.0a1).
- Workshop's internal `word_connectors.json` / `euphony.json` read via `closest_lang` resolution.

`grep -rn 'resource_files|SkillResources|MustacheDialogRenderer|ResourceFile|RegexExtractor' ovos_workshop/` matches only inside `resource_files.py` and the legacy mixin.

## One private removal

`UniversalSkill._load_lang` — a dead override constructing a `SkillResources`; never part of the public API (underscore-prefixed). The base-class `load_lang` (public, on every `OVOSSkill`) now returns a `LocaleResources` instead of a `SkillResources`, but caller patterns are identical and the `load_*` methods callers use exist on both.

## Pin bumps

| Dep | Floor | Why |
|---|---|---|
| `ovos-utils` | `>=0.11.1a1` | `standardize_lang_tag(macro=True)` region-preserving fix ([ovos-utils#377](https://github.com/OpenVoiceOS/ovos-utils/pull/377)). Without it `SessionManager` rewrote `session.lang` from `en-US` to `en` on every message. |
| `ovos-spec-tools` | `>=0.6.0a1` | `LocaleResources.find` / `load_blacklist` / `load_vocabulary` + empty-msg_type construction + `find_lang_dir`. |
| `ovos_bus_client` | `>=2.0.0a4` | `Session.deserialize` keeps the region. |

## Tests

**Unit-test coverage on the mixin:**
- `test/unittests/skills/test_legacy_resources.py` — every shim, every legacy file role, deprecation warnings, source-precedence chain, user-override > skill > core.
- `test/unittests/skills/test_legacy_skill_omnibus.py` — one `_LegacyOmnibusSkill` exercising every deprecated API and every legacy resource file type in a single `initialize()` lifecycle. Single-file tripwire.
- `test/unittests/skills/test_regex_loading.py` — Adapt regex via `load_regex_files`.

**New ovoscope end-to-end tripwires for the highest-risk paths:**
- `test/end2end/test_regex_skill.py` — .rx → Adapt match.
- `test/end2end/test_universal_skill.py` — `UniversalSkill` cross-language `speak_dialog` + `voc_match` + realistic Portuguese-user-with-English-skill round trip.
- `test/end2end/test_speak_dialog.py` — `speak_dialog` → `render_dialog` → `LocaleResources.load_dialog` → `render` with `{slot}` + `<voc>`.
- `test/end2end/test_padacioso_intent_file.py` — `register_intent_file` → `_locate_lang_file` → padacioso match.
- `test/end2end/test_padacioso_entity_file.py` — `register_entity_file` → bus event carrying the resolved .entity path + parsed samples. (Asserts on the registration plumbing, not slot-fill — `.entity` files in OVOS are training-data hints, not strict constraints.)
- `test/end2end/test_voc_match.py` — `voc_match` on vanilla `OVOSSkill`.

## Migration path for skill authors

Skills migrate incrementally; each `DeprecationWarning` points at the spec-tools-backed replacement. **No skill needs to change in this release cycle.** The mixin and `resource_files` both have a one-major-release deprecation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebase note (2026-07-26)

Rebased onto current `dev` (tip `c59df90`), which had merged #491 (INTENT-4
keyword-casing e2e regression guard), #493 (padacioso floor `>=2.2.1a1`),
#495 (`SessionManager.bus` save/restore in e2e suites) and #497 (dual-bind
intent dispatch: `register_intent_file` binds both the legacy
`<id>:<file>.intent` and canonical `<id>:<file>` events; `disable_intent`
unbinds both).

Conflicts were in `ovos_workshop/skills/ovos.py` only (this PR and #497 both
touch intent/vocab registration):

- Import line: kept `munge_regex` / `munge_intent_parser` (#497) and dropped
  the now-superseded `ResourceFile` / `find_resource` / `SkillResources`
  import from this branch.
- `load_vocab_files`: kept this branch's `vocabulary_keywords()` iteration
  (the `LocaleResources`-backed rewrite) but **without** the `.title()` call
  on the `.voc` filename — `.title()` on a CamelCase filename like
  `HelloWorldKeyword` mangles it to `Helloworldkeyword`, which is exactly the
  regression #491 guards against. Calls `register_keyword` (canonical,
  dual-emits) rather than the deprecated `register_adapt_keyword` alias.
- `register_entity_file`: kept this branch's `register_padatious_entity` +
  `self._locale_resources.load_blacklist` (the API `resources.load_blacklist_file`
  no longer exists on `LocaleResources`).
- `register_vocabulary` / `register_regex`: kept this branch's
  `self._resource_lang` + `munge_regex` versions (the `_resource_lang`
  property is this branch's replacement for `self.lang` throughout the
  file).
- `register_intent_file`'s INTENT-4 dual-bind block (bind both
  `<id>:<file>.intent` and canonical `<id>:<file>` to the handler) and
  `disable_intent`'s matching unbind-both came through **unconflicted** —
  #497's behaviour is intact.

Post-rebase, `git diff --check` and the full suite surfaced pre-existing
bugs in this branch's own rewrite (not caused by the rebase, just newly
exercised once the base moved):

- `register_intent_file` referenced an undefined `resources` local when
  building `vocabs=` for `register_template` — fixed to
  `self._locale_resources.vocabularies(lang)`.
- `load_regex_files` pre-munged `.rx` group names with the skill's alnum id
  and then handed them to `register_adapt_regex`, which munges again —
  double-prefixing desynced the group name from what
  `IntentBuilder.require()` expects, so Adapt regex intents never matched.
  Now handed off unmunged (`register_adapt_regex` already owns it).
- `test_register_entity_file` (unit test) still asserted the old
  `register_entity(entity_name, samples, ...)` signature against a skill
  whose `register_entity_file` now calls `register_padatious_entity(name,
  filename, lang, blacklist=...)` — updated the assertions.
- `test/end2end/universal_locale/locale/pt-PT/fact.intent` shipped as an
  empty file, so padacioso had nothing to match "conta-me um facto sobre
  gatos" against — filled in the Portuguese templates. Also bumped that
  round-trip's speak-wait from 10s to 15s (matching
  `test_padacioso_intent_file.py`'s timeout) since two-language
  padatious/padacioso training occasionally ran past 10s under full-suite
  load.

New tip: `9f4883f`. Fresh venv, `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest
test/` — 570 passed, two consecutive clean full-suite runs. Force-pushed
with `--force-with-lease` against the pre-rebase remote sha. Still draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent dialog rendering helper for template substitution and vocabulary references.
  * Improved locale-aware resource discovery with better language fallback.

* **Bug Fixes**
  * Corrected translation direction and language handling in multi-language skills.
  * Improved vocabulary matching and regex intent resolution reliability.

* **Deprecations**
  * Legacy resource APIs and decorator patterns now emit runtime deprecation warnings; backwards-compatible shims retained.

* **Tests**
  * Extensive unit and end-to-end tests for dialogs, intents, entities, voc matching, regexes, and multilingual behavior.

* **Chores**
  * Excluded temporary test config from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-workshop/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
