### PR TITLE
fix(deps): allow ovos-bus-client 2.x (widen cap to <3.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "jarbasAi", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 dependencies = [
     "ovos-utils>= 0.7.0,<1.0.0",
-    "ovos_bus_client>=1.3.8a1,<2.0.0",
+    "ovos_bus_client>=1.3.8a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-yes-no-plugin>=0.3.0,<1.0.0",
     "ovos-option-matcher-fuzzy-plugin>=0.0.1,<1.0.0",


### PR DESCRIPTION
ovos-bus-client 2.x only dropped the bundled hivemind agent protocol + messagebus solver (ovos-bus-client#207) — no API break (#215). Widen `<2.0.0`→`<3.0.0` so 2.x is permitted (1.x stays default). Part of the stack-wide migration letting HiveMind resolve the duplicate `hivemind-ovos-agent-plugin` entry-point collision.