### PR TITLE
feat: deprecate OVOSCommonPlaybackSkill in favor of MediaProvider plugins

### DIFF
--- a/docs/skill-classes.md
+++ b/docs/skill-classes.md
@@ -136,6 +136,15 @@ class MyQuerySkill(CommonQuerySkill):
 
 **Module:** `ovos_workshop.skills.common_play`
 
+> **Deprecated (OVOS-OCP-1):** `OVOSCommonPlaybackSkill` and the
+> `@ocp_search` / `@ocp_featured_media` decorators are superseded by the
+> **MediaProvider** plugin type (`opm.media.provider`). New media catalogs
+> should ship as `ovos-media-provider-*` plugins that return
+> `mediavocab.Release` objects and are loaded in-process by the OCP pipeline,
+> instead of media-provider skills queried over the bus. The constructor emits
+> a deprecation warning (removal targeted for `2.0.0`). See
+> [OVOS-OCP-1](https://github.com/OpenVoiceOS/architecture/blob/dev/ovos-ocp-1.md).
+
 Integrates with OCP (OpenVoiceOS Common Play) for media playback. Uses `@ocp_search`, `@ocp_play`, and related decorators to respond to play requests and appear in the OCP media browser.
 
 ```python

--- a/ovos_workshop/skills/common_play.py
+++ b/ovos_workshop/skills/common_play.py
@@ -19,7 +19,7 @@ from typing import List, Callable, Optional, Dict
 from ovos_bus_client import Message
 from ovos_config.locations import get_xdg_cache_save_path
 from ovos_utils import camel_case_split
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_workshop.skills.ovos import OVOSSkill
 try:
     from ahocorasick_ner import AhocorasickNER
@@ -97,6 +97,15 @@ class OVOSCommonPlaybackSkill(OVOSSkill):
          
         Initializes internal state for OCP entity recognition, playback control, and skill aliases.
         """
+        log_deprecation(
+            "OVOSCommonPlaybackSkill (and the @ocp_search / @ocp_featured_media "
+            "decorators) are superseded by the MediaProvider plugin type "
+            "('opm.media.provider'). New media catalogs should ship as "
+            "'ovos-media-provider-*' plugins that return mediavocab.Release objects "
+            "and are loaded in-process by the OCP pipeline, instead of media-provider "
+            "skills queried over the bus. See OVOS-OCP-1: "
+            "https://github.com/OpenVoiceOS/architecture/blob/dev/ovos-ocp-1.md",
+            "2.0.0")
         self.supported_media = supported_media or [MediaType.GENERIC]
         self.skill_aliases = []
         self.skill_voc_filename = skill_voc_filename


### PR DESCRIPTION
Phase of the ovos-media modernization: media catalogs move from **OCP skills** to the **MediaProvider plugin type** (`opm.media.provider`), loaded in-process by the OCP pipeline and returning `mediavocab.Release` (see [OVOS-OCP-1](https://github.com/OpenVoiceOS/architecture/blob/dev/ovos-ocp-1.md) and the `ovos-media-provider-*` plugins).

This adds a **non-breaking deprecation notice** to `OVOSCommonPlaybackSkill.__init__` steering authors to the new model. Existing OCP skills keep working — hard removal is a future major. Draft: merge once the maintainer is ready to surface the deprecation.

19 common_play tests pass.