### PR TITLE
feat: dual-emit speak on ovos.utterance.speak (namespace migration)

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -36,7 +36,6 @@ from ovos_bus_client.apis.ocp import OCPInterface
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_bus_client.session import SessionManager, Session
 from ovos_bus_client.util import get_message_lang
-from ovos_bus_client.util.migration import emit_migration_pair
 from ovos_config.config import Configuration
 from ovos_config.locations import get_xdg_cache_save_path
 from ovos_config.locations import get_xdg_config_save_path
@@ -1555,17 +1554,16 @@ class OVOSSkill:
         # bus-namespace migration: "speak" -> "ovos.utterance.speak"
         # (architecture PIPELINE-1 §9.6). During the migration we dual-emit on
         # both topics so consumers on either namespace are reached; they dedupe
-        # on content. Gated on `legacy_namespace` (default True). The full
-        # payload (incl. expect_response/meta) is kept on both emissions; the
-        # wait/expect_response handshake is keyed on the session, not the topic,
-        # so it is unaffected by the topic change.
+        # on content. Always emit the new topic; also emit the legacy "speak"
+        # while `legacy_namespace` is True (default). The full payload (incl.
+        # expect_response/meta) is kept on both emissions; the wait/
+        # expect_response handshake is keyed on the session, not the topic, so
+        # it is unaffected by the topic change.
         # TODO: remove the legacy "speak" branch in the next major release,
         #  once every node emits the ovos.* topic only.
         if Configuration().get("legacy_namespace", True):
-            emit_migration_pair(self.bus, m, "speak",
-                                "ovos.utterance.speak", data)
-        else:
-            self.bus.emit(m.forward("ovos.utterance.speak", data))
+            self.bus.emit(m.forward("speak", data))
+        self.bus.emit(m.forward("ovos.utterance.speak", data))
 
         if wait:
             timeout = 15 if isinstance(wait, bool) else wait

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -36,6 +36,7 @@ from ovos_bus_client.apis.ocp import OCPInterface
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_bus_client.session import SessionManager, Session
 from ovos_bus_client.util import get_message_lang
+from ovos_bus_client.util.migration import emit_migration_pair
 from ovos_config.config import Configuration
 from ovos_config.locations import get_xdg_cache_save_path
 from ovos_config.locations import get_xdg_config_save_path
@@ -1551,7 +1552,20 @@ class OVOSSkill:
                                  meta["translation_data"])
             m.context["translation_data"] = tx_data
 
-        self.bus.emit(m)
+        # bus-namespace migration: "speak" -> "ovos.utterance.speak"
+        # (architecture PIPELINE-1 §9.6). During the migration we dual-emit on
+        # both topics so consumers on either namespace are reached; they dedupe
+        # on content. Gated on `legacy_namespace` (default True). The full
+        # payload (incl. expect_response/meta) is kept on both emissions; the
+        # wait/expect_response handshake is keyed on the session, not the topic,
+        # so it is unaffected by the topic change.
+        # TODO: remove the legacy "speak" branch in the next major release,
+        #  once every node emits the ovos.* topic only.
+        if Configuration().get("legacy_namespace", True):
+            emit_migration_pair(self.bus, m, "speak",
+                                "ovos.utterance.speak", data)
+        else:
+            self.bus.emit(m.forward("ovos.utterance.speak", data))
 
         if wait:
             timeout = 15 if isinstance(wait, bool) else wait

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "jarbasAi", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 dependencies = [
     "ovos-utils>= 0.7.0,<1.0.0",
-    "ovos_bus_client>=1.3.8a1,<3.0.0",
+    "ovos_bus_client>=2.1.2a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-yes-no-plugin>=0.3.0,<1.0.0",
     "ovos-option-matcher-fuzzy-plugin>=0.0.1,<1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "jarbasAi", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 dependencies = [
     "ovos-utils>= 0.7.0,<1.0.0",
-    "ovos_bus_client>=2.1.2a1,<3.0.0",
+    "ovos_bus_client>=2.2.0a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-yes-no-plugin>=0.3.0,<1.0.0",
     "ovos-option-matcher-fuzzy-plugin>=0.0.1,<1.0.0",

--- a/test/unittests/skills/test_ovos.py
+++ b/test/unittests/skills/test_ovos.py
@@ -134,3 +134,60 @@ class TestOVOSSkill(unittest.TestCase):
         self.assertIsInstance(skill, OVOSSkill)
         self.assertNotIsInstance(skill, OVOSAbstractApplication)
 
+
+class TestSpeakNamespaceMigration(unittest.TestCase):
+    """speak -> ovos.utterance.speak bus-namespace migration (dual-emit)."""
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.skill = OVOSSkill(bus=self.bus, skill_id="test_speak_ns")
+        self.emitted = []
+        # FakeBus dispatches by exact msg_type, so subscribe to both topics
+        self.bus.on("speak", lambda m: self.emitted.append(m))
+        self.bus.on("ovos.utterance.speak",
+                    lambda m: self.emitted.append(m))
+
+    def _types(self):
+        return [m.msg_type for m in self.emitted]
+
+    def test_dual_emit_when_legacy_namespace(self):
+        from unittest.mock import patch
+        cfg = {"legacy_namespace": True}
+        with patch("ovos_workshop.skills.ovos.Configuration",
+                   return_value=cfg):
+            self.skill.speak("hello world")
+        # both the legacy and the new topic are emitted
+        self.assertIn("speak", self._types())
+        self.assertIn("ovos.utterance.speak", self._types())
+        self.assertEqual(len(self.emitted), 2)
+        # identical payload on both, all fields preserved
+        for m in self.emitted:
+            self.assertEqual(m.data["utterance"], "hello world")
+            self.assertIn("expect_response", m.data)
+            self.assertIn("meta", m.data)
+            self.assertIn("lang", m.data)
+            self.assertEqual(m.data["meta"]["skill"], "test_speak_ns")
+            # context preserved on both emissions
+            self.assertEqual(m.context.get("skill_id"), "test_speak_ns")
+
+    def test_only_new_topic_when_legacy_disabled(self):
+        from unittest.mock import patch
+        cfg = {"legacy_namespace": False}
+        with patch("ovos_workshop.skills.ovos.Configuration",
+                   return_value=cfg):
+            self.skill.speak("goodbye", expect_response=True)
+        self.assertEqual(self._types(), ["ovos.utterance.speak"])
+        m = self.emitted[0]
+        self.assertEqual(m.data["utterance"], "goodbye")
+        # expect_response carried on the new topic too
+        self.assertTrue(m.data["expect_response"])
+
+    def test_default_is_dual_emit(self):
+        # no legacy_namespace key -> defaults to True (dual-emit during migration)
+        from unittest.mock import patch
+        with patch("ovos_workshop.skills.ovos.Configuration",
+                   return_value={}):
+            self.skill.speak("default behaviour")
+        self.assertIn("speak", self._types())
+        self.assertIn("ovos.utterance.speak", self._types())
+


### PR DESCRIPTION
## What

`OVOSSkill.speak()` now participates in the `speak` → `ovos.utterance.speak` bus-namespace migration (architecture **PIPELINE-1 §9.6**).

During the migration nodes upgrade out of lockstep (e.g. a HiveMind satellite vs core), so the **producer dual-emits** the utterance on both the legacy `speak` topic and the new `ovos.utterance.speak` topic. Consumers listen on both and dedup on content (see ovos-audio companion PR).

- Gated on `Configuration().get("legacy_namespace", True)`:
  - **True** (default, during migration) → dual-emit on both topics via `emit_migration_pair`.
  - **False** → emit only the new `ovos.utterance.speak` topic.
- The **full payload** (`utterance`, `expect_response`, `meta`, `lang`) and message **context** (`skill_id`, `translation_data`) are preserved on **both** emissions (`Message.forward` deep-copies context).
- The `wait`/`expect_response` handshake is keyed on the **session** (`SessionManager.wait_while_speaking`), not on the topic, so it is unaffected by the topic change.

Flagged in code as a backwards-compat aid, removable next major (legacy branch + the `speak` emission go away once every node emits `ovos.*` only).

## Changes
- `ovos_workshop/skills/ovos.py`: import `emit_migration_pair`; dual-emit in `speak()`.
- `pyproject.toml`: pin `ovos_bus_client>=2.1.2a1` (prerelease floor that carries the migration helper).
- `test/unittests/skills/test_ovos.py`: `TestSpeakNamespaceMigration` — asserts both topics emitted when `legacy_namespace=True` (and by default), only the new topic when `False`, payload/context preserved.

## Stacking / CI
Stacked on **OpenVoiceOS/ovos-bus-client#228** (`feat/namespace-migration-dedup`), which adds `TransitionalDeduplicator` / `utterance_key` / `emit_migration_pair`. That release is unpublished, so the pinned `>=2.1.2a1` floor is unresolvable on PyPI and **CI will be red until ovos-bus-client publishes**. Tests pass locally against the bus-client feature branch (17/17 in `test_ovos.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)