### PR TITLE
feat: emit OVOS spec topic ovos.utterance.speak

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -36,6 +36,7 @@ from ovos_bus_client.apis.ocp import OCPInterface
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_bus_client.session import SessionManager, Session
 from ovos_bus_client.util import get_message_lang
+from ovos_spec_tools import SpecMessage
 from ovos_config.config import Configuration
 from ovos_config.locations import get_xdg_cache_save_path
 from ovos_config.locations import get_xdg_config_save_path
@@ -1541,8 +1542,8 @@ class OVOSSkill:
 
         # grab message that triggered speech so we can keep context
         message = dig_for_message()
-        m = message.forward("speak", data) if message \
-            else Message("speak", data)
+        m = message.forward(SpecMessage.SPEAK, data) if message \
+            else Message(SpecMessage.SPEAK, data)
         m.context["skill_id"] = self.skill_id
 
         # update any auto-translation metadata in message.context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,9 @@ authors = [{name = "jarbasAi", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 dependencies = [
     "ovos-utils>= 0.7.0,<1.0.0",
-    "ovos_bus_client>=1.3.8a1,<3.0.0",
+    "ovos_bus_client>=2.2.0a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
+    "ovos-spec-tools>=0.9.0a1",
     "ovos-yes-no-plugin>=0.3.0,<1.0.0",
     "ovos-option-matcher-fuzzy-plugin>=0.0.1,<1.0.0",
     "ovos-number-parser>=0.0.1,<1.0.0",

--- a/test/unittests/test_decorators.py
+++ b/test/unittests/test_decorators.py
@@ -108,7 +108,7 @@ class TestKillableIntents(unittest.TestCase):
         """Assert that a speak message with the given utterance was emitted,
         regardless of the active language tag."""
         spoken = [m for m in self.bus.emitted_msgs
-                  if m.get("type") == "speak"
+                  if m.get("type") == "ovos.utterance.speak"
                   and m.get("data", {}).get("utterance") == utterance]
         self.assertTrue(spoken, f"No speak message with utterance {utterance!r} found "
                                 f"in: {self.bus.emitted_msgs}")


### PR DESCRIPTION
## What

\`OVOSSkill.speak()\` now emits the OVOS spec bus topic \`SpecMessage.SPEAK\` (\`ovos.utterance.speak\`, per OVOS-UTTERANCE spec) instead of the legacy \`speak\` topic.

## Changes

- \`ovos_workshop/skills/ovos.py\`: import \`SpecMessage\` from \`ovos_spec_tools\`; the single bus emission in \`speak()\` now uses \`message.forward(SpecMessage.SPEAK, data)\` / \`Message(SpecMessage.SPEAK, data)\`. Full payload (\`utterance\`, \`expect_response\`, \`meta\`, \`lang\`), forward/context behaviour, and the \`wait\`/\`expect_response\` handshake are unchanged.
- \`pyproject.toml\`: add direct dep \`ovos-spec-tools>=0.9.0a1\`; bump \`ovos_bus_client>=2.2.0a1\`.
- \`test/unittests/test_decorators.py\`: update the \`_assert_spoken\` topic check to \`ovos.utterance.speak\`.

## Scope guarantees

Only the literal bus **topic** \`"speak"\` was migrated. Untouched: the \`speak\`/\`speak_dialog\` method names, \`mycroft.audio.speech.*\` topics, \`recognizer_loop:audio_output_*\` events, and any \`speak\` in docstrings/log strings/dialog keys.

## Backward compatibility

The MessageBusClient namespace-migration feature (both flags default ON) also-emits the legacy \`speak\` topic via \`emit_legacy\` whenever a spec topic is emitted, so existing audio consumers keep receiving it.

## CI status

**RED until** [ovos-spec-tools#26](https://github.com/OpenVoiceOS/ovos-spec-tools/pull/26) (adds \`SpecMessage\`) and [ovos-bus-client#230](https://github.com/OpenVoiceOS/ovos-bus-client/pull/230) publish. Verified locally with \`PYTHONPATH\` pointing at the in-dev \`ovos-spec-tools\` (published release lacks \`SpecMessage\`): \`test_decorators.py\` 26 passed; \`test_base.py\` speak tests 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)