### PR TITLE
fix: allow latest padacioso (widen cap to <3.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "ovos-plugin-manager>=2.4.0a1,<3.0.0",
     "rapidfuzz",
     "langcodes",
-    "padacioso>=1.0.0, <2.0.0",
+    "padacioso>=1.0.0,<3.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Widens `padacioso>=1.0.0,<2.0.0` → `<3.0.0` so the ecosystem can adopt padacioso 2.0 (OVOS-INTENT-1 grammar enforcement). Validated end-to-end against the workshop-9 stack in OpenVoiceOS/ovos-test-harness (conformance suite green with padacioso 2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)