### PR TITLE
refactor: use SpecMessage enum for spec topic strings

### DIFF
--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -6,6 +6,7 @@ from langcodes import closest_match
 from ovos_bus_client.message import Message
 from ovos_bus_client.message import dig_for_message
 from ovos_config.config import Configuration
+from ovos_spec_tools import SpecMessage
 from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_utils.skills import get_non_properties
@@ -200,9 +201,9 @@ class ConversationalSkill(OVOSSkill):
 
         self.bus.emit(response_message)
         if is_latest:
-            self.bus.emit(message.forward("ovos.utterance.handled"))
+            self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
         else:
-            self.bus.emit(message.reply("ovos.utterance.handled"))
+            self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
 
     def _handle_converse_intents(self, message):
         """ called before converse method

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional, List
 
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_config import Configuration
+from ovos_spec_tools import SpecMessage
 from ovos_utils.events import get_handler_name
 from ovos_utils.log import LOG
 from ovos_utils.skills import get_non_properties
@@ -157,7 +158,7 @@ class FallbackSkill(OVOSSkill):
         self.bus.emit(message.forward(
             f"ovos.skills.fallback.{self.skill_id}.response",
             data={"result": status, "fallback_handler": handler_name}))
-        self.bus.emit(message.forward("ovos.utterance.handled"))
+        self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
 
     def register_fallback(self, handler: Callable, priority: int) -> None:
         """

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1472,7 +1472,7 @@ class OVOSSkill:
             message.context["skill_id"] = self.skill_id
             self.bus.emit(message.forward(msg_type, skill_data))
         if is_intent:
-            self.bus.emit(message.forward("ovos.utterance.handled", skill_data))
+            self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED, skill_data))
 
         try:
             if self.settings != self._initial_settings:

--- a/test/unittests/test_ask_e2e.py
+++ b/test/unittests/test_ask_e2e.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
+from ovos_spec_tools import SpecMessage
 from ovos_utils.log import LOG
 from ovos_workshop.skills.ovos import OVOSSkill
 
@@ -34,7 +35,7 @@ class AskYesNoSkill(OVOSSkill):
     def handle_yesno(self, message: Message):
         answer = self.ask_yesno("do you want tea")
         self.bus.emit(message.forward("test.yesno.result", {"answer": answer}))
-        self.bus.emit(message.forward("ovos.utterance.handled"))
+        self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
 
 
 class AskSelectionSkill(OVOSSkill):
@@ -45,7 +46,7 @@ class AskSelectionSkill(OVOSSkill):
         options = message.data.get("options", ["alpha", "beta", "gamma"])
         answer = self.ask_selection(options, numeric=True)
         self.bus.emit(message.forward("test.selection.result", {"answer": answer}))
-        self.bus.emit(message.forward("ovos.utterance.handled"))
+        self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
 
 
 def _inject_response(mc, skill_id: str, utterance: str, session: Session):

--- a/test/unittests/test_decorators.py
+++ b/test/unittests/test_decorators.py
@@ -20,6 +20,7 @@ from time import sleep
 from ovos_workshop.skill_launcher import SkillLoader
 from ovos_utils.fakebus import FakeBus
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 
 
 class TestDecorators(unittest.TestCase):
@@ -108,7 +109,7 @@ class TestKillableIntents(unittest.TestCase):
         """Assert that a speak message with the given utterance was emitted,
         regardless of the active language tag."""
         spoken = [m for m in self.bus.emitted_msgs
-                  if m.get("type") == "ovos.utterance.speak"
+                  if m.get("type") == SpecMessage.SPEAK.value
                   and m.get("data", {}).get("utterance") == utterance]
         self.assertTrue(spoken, f"No speak message with utterance {utterance!r} found "
                                 f"in: {self.bus.emitted_msgs}")


### PR DESCRIPTION
Convert hardcoded SPEC-topic string literals to the `SpecMessage` enum from `ovos-spec-tools` so the spec topics have a single source of truth.

## Changes
Behavior-preserving — each enum `.value` equals the literal string previously emitted/asserted (verified at runtime: `SpecMessage.UTTERANCE_HANDLED.value == "ovos.utterance.handled"`, `SpecMessage.SPEAK.value == "ovos.utterance.speak"`).

**Source:**
- `ovos_workshop/skills/fallback.py` — `"ovos.utterance.handled"` → `SpecMessage.UTTERANCE_HANDLED`
- `ovos_workshop/skills/converse.py` — both the `forward` and `reply` emits → `SpecMessage.UTTERANCE_HANDLED`
- `ovos_workshop/skills/ovos.py` — matched-path emit → `SpecMessage.UTTERANCE_HANDLED` (slated to move to core later; converted now for consistency)

**Tests:**
- `test/unittests/test_ask_e2e.py` — 2 mock-skill emits → `SpecMessage.UTTERANCE_HANDLED`
- `test/unittests/test_decorators.py` — assertion `m.get("type") == SpecMessage.SPEAK.value`

Imports added where missing (`from ovos_spec_tools import SpecMessage`); `ovos.py` already imported it.

## Left untouched (not SpecMessage members)
Legacy/dynamic topics: `mycroft.*`, `ovos.common_play.*`, `ovos.common_query.*`, `{skill_id}` response topics, `MIGRATION_MAP` keys.

## Validation
Fresh `uv` venv; `test_ask_e2e`, `test_decorators`, plus related skill/interaction/import tests — **69 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)