### PR TITLE
fix: intent-layers e2e + utterance.handled test, bump pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "apache-2.0"
 authors = [{name = "jarbasAi", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 dependencies = [
-    "ovos-utils>= 0.7.0,<1.0.0",
+    "ovos-utils>= 0.13.3a2,<1.0.0",  # FakeBus folds before handlers (ovos-utils#396) — keeps in-place add_context mutations alive so intent-layer gating works
     "ovos_bus_client>=2.6.2a2,<3.0.0",  # HandlerLifecycle done-signal util (#246) + singleton-registry SessionManager (2.6.2a2)
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-spec-tools>=1.2.3a1",  # canonical SessionManager registry + OVOS-INTENT-4 intent-definition primitives

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ authors = [{name = "jarbasAi", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 dependencies = [
     "ovos-utils>= 0.7.0,<1.0.0",
-    "ovos_bus_client>=2.6.0a1,<3.0.0",  # HandlerLifecycle done-signal util (#246)
+    "ovos_bus_client>=2.6.2a2,<3.0.0",  # HandlerLifecycle done-signal util (#246) + singleton-registry SessionManager (2.6.2a2)
     "ovos-config>=0.0.12,<3.0.0",
-    "ovos-spec-tools>=0.16.1a2",  # carries the adapt-free intent-definition primitives (OVOS-INTENT-4)
+    "ovos-spec-tools>=1.2.3a1",  # canonical SessionManager registry + OVOS-INTENT-4 intent-definition primitives
     "ovos-yes-no-plugin>=0.3.0,<1.0.0",
     "ovos-option-matcher-fuzzy-plugin>=0.0.1,<1.0.0",
     "ovos-number-parser>=0.0.1,<1.0.0",
@@ -26,9 +26,9 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "ovos-core>=0.0.8a50",
+    "ovos-core>=2.4.0a1",  # orchestrator owns ovos.utterance.handled on the matched path (PIPELINE-1 §9.5)
     "ovoscope>=0.1.0",
-    "ovos-adapt-parser>=1.3.1a1",
+    "ovos-adapt-parser>=1.4.2a1",
     "pytest",
     "pytest-cov",
     "ovos-translate-server-plugin",

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -355,16 +355,41 @@ class TestOVOSSkill(unittest.TestCase):
         self.assertEqual(context["skill_id"], self.skill_id)
         self.assertEqual(context["session"]["session_id"], "sess1")
 
-    def test_on_event_end_is_intent_still_emits_utterance_handled(self):
-        # the ovos.utterance.handled emission must be PRESERVED alongside the
-        # delegated .complete done-signal when is_intent=True
+    def test_on_event_end_intent_defers_utterance_handled_to_core(self):
+        # PIPELINE-1 §9.5: with a modern ovos-core (>=2.3.0a1) the orchestrator
+        # owns the universal `ovos.utterance.handled` end-marker on every
+        # terminal path — the matched path included. Workshop must NOT also
+        # emit it (consumers would see the marker twice); only the delegated
+        # `mycroft.skill.handler.complete` done-signal is emitted here.
+        from unittest.mock import patch
         from ovos_bus_client.message import Message
         from ovos_spec_tools import SpecMessage
         msg = Message("trigger", {}, {})
         skill_data = {"name": "TestSkill.handle_test"}
-        captured = self._capture(OVOSSkill._on_event_end, msg,
-                                 "mycroft.skill.handler", dict(skill_data),
-                                 True)
+        with patch("ovos_workshop.skills.ovos._core_owns_utterance_handled",
+                   return_value=True):
+            captured = self._capture(OVOSSkill._on_event_end, msg,
+                                      "mycroft.skill.handler",
+                                      dict(skill_data), True)
+        types = [c[0] for c in captured]
+        self.assertIn("mycroft.skill.handler.complete", types)
+        self.assertNotIn(SpecMessage.UTTERANCE_HANDLED.value, types)
+
+    def test_on_event_end_intent_emits_utterance_handled_legacy(self):
+        # Migration-window back-compat: with an absent/old ovos-core that does
+        # not yet emit `ovos.utterance.handled` on the matched path, workshop
+        # must still emit it alongside the delegated `.complete` done-signal so
+        # spec consumers always observe exactly one end-marker.
+        from unittest.mock import patch
+        from ovos_bus_client.message import Message
+        from ovos_spec_tools import SpecMessage
+        msg = Message("trigger", {}, {})
+        skill_data = {"name": "TestSkill.handle_test"}
+        with patch("ovos_workshop.skills.ovos._core_owns_utterance_handled",
+                   return_value=False):
+            captured = self._capture(OVOSSkill._on_event_end, msg,
+                                      "mycroft.skill.handler",
+                                      dict(skill_data), True)
         types = [c[0] for c in captured]
         self.assertIn("mycroft.skill.handler.complete", types)
         self.assertIn(SpecMessage.UTTERANCE_HANDLED.value, types)

--- a/test/unittests/skills/test_intent_layers_e2e.py
+++ b/test/unittests/skills/test_intent_layers_e2e.py
@@ -177,11 +177,6 @@ class IntentLayersE2ETest(unittest.TestCase):
                 SessionManager.default_session.context.get_context()]
 
     # tests ------------------------------------------------------------------
-    @pytest.mark.xfail(reason="pre-existing failure on dev, unrelated to "
-                       "OVOS-INTENT-4 producer changes: layer context "
-                       "token is never applied, so gated intents never "
-                       "match (ovos_workshop/decorators/layers.py)",
-                       strict=False)
     def test_layers_advance_in_sequence_and_gate_intents(self):
         skill = self.skill
 
@@ -238,11 +233,6 @@ class IntentLayersE2ETest(unittest.TestCase):
         self.assertEqual(skill.reached,
                          ["begin", "layer0", "layer1", "layer2", "layer3"])
 
-    @pytest.mark.xfail(reason="pre-existing failure on dev, unrelated to "
-                       "OVOS-INTENT-4 producer changes: layer context "
-                       "token is never applied, so gated intents never "
-                       "match (ovos_workshop/decorators/layers.py)",
-                       strict=False)
     def test_inactive_layer_intents_do_not_match(self):
         """With only layer0 active, layer1/2/3 intents must not be selectable."""
         skill = self.skill

--- a/test/unittests/skills/test_intent_layers_e2e.py
+++ b/test/unittests/skills/test_intent_layers_e2e.py
@@ -177,6 +177,11 @@ class IntentLayersE2ETest(unittest.TestCase):
                 SessionManager.default_session.context.get_context()]
 
     # tests ------------------------------------------------------------------
+    @pytest.mark.xfail(reason="pre-existing failure on dev, unrelated to "
+                       "OVOS-INTENT-4 producer changes: layer context "
+                       "token is never applied, so gated intents never "
+                       "match (ovos_workshop/decorators/layers.py)",
+                       strict=False)
     def test_layers_advance_in_sequence_and_gate_intents(self):
         skill = self.skill
 
@@ -233,6 +238,11 @@ class IntentLayersE2ETest(unittest.TestCase):
         self.assertEqual(skill.reached,
                          ["begin", "layer0", "layer1", "layer2", "layer3"])
 
+    @pytest.mark.xfail(reason="pre-existing failure on dev, unrelated to "
+                       "OVOS-INTENT-4 producer changes: layer context "
+                       "token is never applied, so gated intents never "
+                       "match (ovos_workshop/decorators/layers.py)",
+                       strict=False)
     def test_inactive_layer_intents_do_not_match(self):
         """With only layer0 active, layer1/2/3 intents must not be selectable."""
         skill = self.skill


### PR DESCRIPTION
Genuine root-cause fixes for the failing tests on this branch.

## intent-layers e2e (the two xfailed tests) — fixed upstream in OpenVoiceOS/ovos-utils#396

`activate_layer()` -> `set_context()` -> `add_context` -> `handle_add_context` injects the `layer_<name>` token into the default-session `SessionManager` singleton's `context` in place. The token was then wiped before the next match: **`FakeBus.emit` was folding the message's session onto the singleton AFTER the bus handlers ran, using a pre-mutation emit-time snapshot** — `Session.update_from` is last-writer-wins per field (OVOS-SESSION-1 §2), so the post-handler fold wholesale-replaced the singleton's `context` with a stale (token-less) snapshot. Gated intents never matched.

#396 fixes the ordering: `FakeBus.emit` now folds **before** handlers (matching `MessageBusClient.on_message` receive -> fold -> handle order) and drops the post-handler self-broadcast-back fold. The legacy `add_context` -> `sess.context` frame mechanism then survives under folding — no workshop change needed (`IntentLayers` is unchanged). Spec-faithful (every session, default included, still folds — no owner-only guard; the earlier guard attempt #395 was correctly rejected) and backward compatible.

This PR:
- `test_intent_layers_e2e.py`: revert the `xfail` markers added in `2aee2bd`; both tests pass once `ovos-utils >= 0.13.3a2` (#396 release) lands.
- `pyproject.toml`: bump `ovos-utils` floor to `>= 0.13.3a2`.

## utterance.handled test (the hard CI failure) — fixed here

`test_on_event_end_is_intent_still_emits_utterance_handled` (#440) asserted `_on_event_end(is_intent=True)` emits `ovos.utterance.handled`. #442's `_core_owns_utterance_handled()` guard suppresses that emission when `ovos-core >= 2.3.0a1` — the orchestrator owns the PIPELINE-1 §9.5 end-marker on the matched path. CI now installs `ovos-core==2.4.0a1`, so the #440 assertion is stale. Replaced with two deterministic monkeypatched branches:
- `test_on_event_end_intent_defers_utterance_handled_to_core` — modern core; workshop must NOT emit it.
- `test_on_event_end_intent_emits_utterance_handled_legacy` — absent/old core; workshop still emits (migration-window back-compat).

## Pin floors (match CI)

`ovos_bus_client >= 2.6.2a2` (singleton-registry `SessionManager`), `ovos-spec-tools >= 1.2.3a1`, `ovos-core >= 2.4.0a1` (test, §9.5), `ovos-adapt-parser >= 1.4.2a1` (test), `ovos-utils >= 0.13.3a2` (pending #396 release).

## Sequencing

The two layer-e2e tests' CI stays red until OpenVoiceOS/ovos-utils#396 merges and releases `0.13.3a2`. Merge #396 first, then this.

Verified locally with the #396 fix installed: both `test_intent_layers_e2e.py` tests pass and the three `_on_event_end` tests pass (released `ovos-adapt-parser`, no bridge needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)