### PR TITLE
feat: handle targeted stop on the reserved `<skill_id>:stop` topic (STOP-1 §2)

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1098,6 +1098,9 @@ class OVOSSkill:
         """
         self.add_event('mycroft.stop', self._handle_session_stop, speak_errors=False)
         self.add_event(f"{self.skill_id}.stop", self._handle_session_stop, speak_errors=False)
+        # OVOS-STOP-1 §2: a targeted stop is dispatched on the reserved
+        # intent_name `stop`, i.e. the PIPELINE-1 `<skill_id>:stop` topic.
+        self.add_event(f"{self.skill_id}:stop", self._handle_session_stop, speak_errors=False)
         self.add_event(f"{self.skill_id}.stop.ping", self._handle_stop_ack, speak_errors=False)
         self.add_event(f"{self.skill_id}.converse.get_response", self.__handle_get_response, speak_errors=False)
 

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -540,6 +540,19 @@ class TestOVOSSkill(unittest.TestCase):
         # TODO
         pass
 
+    def test_targeted_stop_colon_topic(self):
+        # OVOS-STOP-1 §2: a skill answers a targeted stop dispatched on the
+        # reserved intent_name `stop` (`<skill_id>:stop`) exactly as it does the
+        # legacy `<skill_id>.stop` topic.
+        from ovos_bus_client.message import Message
+        responses = []
+        self.bus.on(f"{self.skill_id}.stop.response",
+                    lambda m: responses.append(m))
+        self.skill.stop = Mock(return_value=True)
+        self.bus.emit(Message(f"{self.skill_id}:stop", {}, {}))
+        self.skill.stop.assert_called_once()
+        self.assertTrue(responses, "no stop.response for the <skill_id>:stop dispatch")
+
     def test_stop(self):
         self.skill.stop()
 


### PR DESCRIPTION
OVOS-STOP-1 §2 dispatches a **targeted** stop under the reserved intent_name
`stop` — the PIPELINE-1 `<skill_id>:stop` topic. Today `OVOSSkill` only listens
on the legacy `<skill_id>.stop` (dot). This registers `<skill_id>:stop` (colon)
on the same session-stop handler so a skill answers the spec-named dispatch.

Additive and fully backward compatible — the `<skill_id>.stop` and `mycroft.stop`
handlers are untouched. This is the skill-side half of the STOP-1 §2/§3.1
`intent_name` rename; the core stop plugin (ovos-core #777) emits the
`<target_skill_id>:stop` dispatch.

Test: `test_targeted_stop_colon_topic` asserts a skill's stop path runs for the
`<skill_id>:stop` dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)