### PR TITLE
feat: support .blacklist locale resource for intents (OVOS-INTENT-2)

### DIFF
--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -41,6 +41,7 @@ SkillResourceTypes = namedtuple(
         "template",
         "vocabulary",
         "word",
+        "blacklist",
         "qml",
         "json"
     ]
@@ -258,6 +259,7 @@ class ResourceType:
             template="dialog",
             vocab="vocab",
             word="dialog",
+            blacklist="vocab",
             qml="gui"
         )
 
@@ -549,6 +551,23 @@ class WordFile(ResourceFile):
         return word
 
 
+class BlacklistFile(ResourceFile):
+    """Defines a blacklist file, a slot-free list of phrases that should
+    prevent the sibling intent (same base name) from matching."""
+
+    def load(self) -> List[str]:
+        """Load the phrases contained in a blacklist file.
+
+        Returns:
+            A list of phrases, one per line.
+        """
+        phrases = []
+        if self.file_path is not None:
+            for line in self._read():
+                phrases.append(line.lower())
+        return phrases
+
+
 class SkillResources:
     def __init__(self, skill_directory: str,
                  language: str,
@@ -609,6 +628,7 @@ class SkillResources:
             template=ResourceType("template", ".template", self.language),
             vocabulary=ResourceType("vocab", ".voc", self.language),
             word=ResourceType("word", ".word", self.language),
+            blacklist=ResourceType("blacklist", ".blacklist", self.language),
             qml=ResourceType("qml", ".qml"),
             json=ResourceType("json", ".json", self.language)
         )
@@ -662,6 +682,21 @@ class SkillResources:
         intent_file = IntentFile(self.types.intent, name)
         intent_file.data = data
         return intent_file.load(entities)
+
+    def load_blacklist_file(self, name: str) -> List[str]:
+        """
+        Loads the phrases contained in a blacklist file.
+
+        A blacklist file is a slot-free list of phrases that suppress the
+        sibling intent (the ``.intent`` sharing its base name) from matching.
+
+        Args:
+            name: name of the blacklist file (no extension needed)
+        Returns:
+            A list of blacklisted phrases
+        """
+        blacklist_file = BlacklistFile(self.types.blacklist, name)
+        return blacklist_file.load()
 
     def locate_qml_file(self, name: str) -> str:
         qml_file = QmlFile(self.types.qml, name)

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1346,6 +1346,11 @@ class OVOSSkill:
             for enty in voc_blacklist or []:
                 disallowed_strings += self.voc_list(enty, lang=lang)
 
+            # OVOS-INTENT-2: a sibling "<intent>.blacklist" locale file lists
+            # slot-free phrases that should suppress this intent from matching
+            blacklist_name = intent_file.rsplit(".", 1)[0]
+            disallowed_strings += resources.load_blacklist_file(blacklist_name)
+
             self.intent_service.register_padatious_intent(name, filename, lang, string_blacklist=disallowed_strings)
         if handler:
             self.add_event(name, handler, 'mycroft.skill.handler',

--- a/test/unittests/ovos_tskill_blacklist/locale/en-US/bar.intent
+++ b/test/unittests/ovos_tskill_blacklist/locale/en-US/bar.intent
@@ -1,0 +1,1 @@
+what time is it

--- a/test/unittests/ovos_tskill_blacklist/locale/en-US/foo.blacklist
+++ b/test/unittests/ovos_tskill_blacklist/locale/en-US/foo.blacklist
@@ -1,0 +1,3 @@
+# phrases that must never trigger foo
+turn on the news
+activate the alarm

--- a/test/unittests/ovos_tskill_blacklist/locale/en-US/foo.intent
+++ b/test/unittests/ovos_tskill_blacklist/locale/en-US/foo.intent
@@ -1,0 +1,2 @@
+turn on the {thing}
+activate the {thing}

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -143,3 +143,51 @@ class TestSkillNew(unittest.TestCase):
         self.assertEqual(args.skill_id, "args")
         self.assertEqual(args.bus, bus)
         self.assertEqual(args.gui, gui)
+
+
+class TestIntentBlacklistFile(unittest.TestCase):
+    """OVOS-INTENT-2: a sibling '<intent>.blacklist' locale file feeds the
+    intent registration blacklist alongside the 'voc_blacklist' param."""
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.bus.emitted_msgs = []
+
+        def get_msg(msg):
+            self.bus.emitted_msgs.append(json.loads(msg))
+
+        self.bus.on("message", get_msg)
+
+        res_dir = f"{dirname(__file__)}/ovos_tskill_blacklist"
+        self.skill = OVOSSkill(skill_id="blacklist.test", bus=self.bus,
+                               resources_dir=res_dir)
+
+    def _register_payload(self, intent_name):
+        for msg in self.bus.emitted_msgs:
+            if msg["type"] == "padatious:register_intent" and \
+                    msg["data"]["name"].endswith(intent_name):
+                return msg["data"]
+        return None
+
+    def test_intent_with_blacklist_file(self):
+        self.bus.emitted_msgs = []
+        self.skill.register_intent_file("foo.intent", None)
+        data = self._register_payload("foo.intent")
+        self.assertIsNotNone(data)
+        self.assertIn("turn on the news", data["blacklisted_words"])
+        self.assertIn("activate the alarm", data["blacklisted_words"])
+
+    def test_intent_without_blacklist_file(self):
+        self.bus.emitted_msgs = []
+        self.skill.register_intent_file("bar.intent", None)
+        data = self._register_payload("bar.intent")
+        self.assertIsNotNone(data)
+        self.assertEqual(data["blacklisted_words"], [])
+
+    def test_voc_blacklist_param_still_merges(self):
+        self.bus.emitted_msgs = []
+        # even without any matching voc, the .blacklist phrases must be present
+        self.skill.register_intent_file("foo.intent", None, voc_blacklist=[])
+        data = self._register_payload("foo.intent")
+        self.assertIsNotNone(data)
+        self.assertIn("turn on the news", data["blacklisted_words"])


### PR DESCRIPTION
## What

Adds support for the OVOS-INTENT-2 `<intent>.blacklist` locale resource file: a slot-free list of phrases (base name = the `.intent` it suppresses) that must never trigger the sibling intent.

Previously ovos-workshop had no `.blacklist` resource type, no loader, and `register_intent_file` never looked up a sibling `<intent>.blacklist`. The intent-registration blacklist field was only ever fed from the `voc_blacklist=` param.

## Changes

- `ovos_workshop/resource_files.py`
  - `blacklist` entry added to the `SkillResourceTypes` namedtuple and to `_define_resource_types` (`.blacklist` extension), plus the legacy subdirectory map.
  - New `BlacklistFile` resource class (flat list of phrases, mirroring the `WordFile`/`ListFile` shape).
  - New `SkillResources.load_blacklist_file(name)` helper mirroring `load_intent_file`.
- `ovos_workshop/skills/ovos.py` `register_intent_file`: after building `disallowed_strings` from `voc_blacklist`, it now also loads `<intent_basename>.blacklist` for the lang and merges the phrases in before registration. Purely additive; the existing `voc_blacklist` path is unchanged.

## Flow to the spec §6 blacklist field

A shipped `foo.blacklist` sitting next to `foo.intent` is loaded per-lang and merged into `disallowed_strings`, which is passed as `string_blacklist` to `register_padatious_intent`, which emits it as the `blacklisted_words` field of the intent-registration payload (the §6 blacklist field, aka `blacklist` in the INTENT-4 template registration).

## Tests

New `TestIntentBlacklistFile` in `test/unittests/test_skill.py` with a fixture skill (`ovos_tskill_blacklist`): asserts a `.blacklist` file's phrases land in the emitted registration payload, and that an intent with no `.blacklist` yields an empty blacklist (back-compat). 31 touched tests pass in a fresh uv venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)