### PR TITLE
fix: don't double-emit ovos.utterance.handled from fallback/converse when core owns it

### DIFF
--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -14,7 +14,7 @@ from padacioso import IntentContainer
 
 from ovos_workshop.decorators.killable import AbortEvent, killable_event, AbortQuestion
 from ovos_workshop.resource_files import ResourceFile
-from ovos_workshop.skills.ovos import OVOSSkill
+from ovos_workshop.skills.ovos import _core_owns_utterance_handled, OVOSSkill
 
 
 class ConversationalSkill(OVOSSkill):
@@ -200,10 +200,15 @@ class ConversationalSkill(OVOSSkill):
                 response_message.data["error"] =  repr(e)
 
         self.bus.emit(response_message)
-        if is_latest:
-            self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
-        else:
-            self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
+        if not _core_owns_utterance_handled():
+            # PIPELINE-1 §9.5: the orchestrator owns ovos.utterance.handled. With a
+            # core that emits it on every terminal path (>=2.3.0a1) we must not also
+            # emit it here, or consumers see the end-marker twice; only emit for an
+            # older/absent core during the migration window.
+            if is_latest:
+                self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
+            else:
+                self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
 
     def _handle_converse_intents(self, message):
         """ called before converse method

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -23,7 +23,7 @@ from ovos_utils.log import LOG
 from ovos_utils.skills import get_non_properties
 
 from ovos_workshop.decorators.killable import AbortEvent, killable_event
-from ovos_workshop.skills.ovos import OVOSSkill
+from ovos_workshop.skills.ovos import _core_owns_utterance_handled, OVOSSkill
 
 
 class FallbackSkill(OVOSSkill):
@@ -158,7 +158,12 @@ class FallbackSkill(OVOSSkill):
         self.bus.emit(message.forward(
             f"ovos.skills.fallback.{self.skill_id}.response",
             data={"result": status, "fallback_handler": handler_name}))
-        self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
+        if not _core_owns_utterance_handled():
+            # PIPELINE-1 §9.5: the orchestrator owns ovos.utterance.handled. With a
+            # core that emits it on every terminal path (>=2.3.0a1) we must not also
+            # emit it here, or consumers see the end-marker twice; only emit for an
+            # older/absent core during the migration window.
+            self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
 
     def register_fallback(self, handler: Callable, priority: int) -> None:
         """


### PR DESCRIPTION
## What
The matched-intent path already guards its `ovos.utterance.handled` emission on
`_core_owns_utterance_handled()` (PIPELINE-1 §9.5 — ovos-core >=2.3.0a1 owns the
universal end-marker on *every* terminal path). `FallbackSkill` and
`ConversationalSkill` still emitted it unconditionally, so against a core that
owns it the end-marker fired **twice** (skill + orchestrator). This guards both
on the same version check.

## Why
Surfaced by `ovos-test-harness` conformance suites against the spec-adoption
stack: `test_fallback1 TestSec6QueryResponse.test_exactly_one_handled`,
`test_converse1 TestSec4ConverseRoundTrip.test_followup_terminates_once`, and
`test_common_query1 TestSec9NoWinnerReachesFallback.test_non_question_terminates_once`
each saw 2 end-markers instead of 1.

Stacked on `feat/intent-4-producer` (#431) so the harness combo can pin one
workshop branch carrying both the INTENT-4 producer and this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)