### PR TITLE
fix: expand inline <voc> refs before registering intents to the engine

### DIFF
--- a/ovos_workshop/intents.py
+++ b/ovos_workshop/intents.py
@@ -13,7 +13,7 @@ from ovos_utils.log import LOG, log_deprecation
 # the single source of truth is the spec. The `IntentServiceInterface` producer
 # (and the munge_* helpers) below consume these definitions.
 from ovos_spec_tools import (Intent, IntentBuilder, open_intent_envelope,
-                             expand, MalformedTemplate)
+                             inline_keywords, expand, MalformedTemplate)
 
 
 def _drop_malformed_samples(samples: List[str], name: str, lang: str,
@@ -294,7 +294,8 @@ class IntentServiceInterface:
 
     def register_padatious_intent(self, intent_name: str, filename: str,
                                   lang: str, string_blacklist: Optional[List[str]] = None,
-                                  slot_blacklist: Optional[Dict[str, List[str]]] = None):
+                                  slot_blacklist: Optional[Dict[str, List[str]]] = None,
+                                  vocabs: Optional[Dict[str, List[str]]] = None):
         """
         Register a Padatious intent file with the intent service.
         @param intent_name: Unique intent identifier
@@ -306,6 +307,11 @@ class IntentServiceInterface:
         @param slot_blacklist: OVOS-INTENT-2 §4.3 slot-value exclusions keyed by
             slot name, ``{slot: [excluded phrases]}`` — values that MUST NOT
             fill the named ``{slot}`` (each slot's sibling `<slot>.blacklist`).
+        @param vocabs: ``{name: members}`` of the sibling vocabularies, so an
+            inline ``<name>`` reference (OVOS-INTENT-1 §3.7) is baked into the
+            samples as an ``(a|b|c)`` group before they reach the engine — the
+            padatious/padacioso bus protocol carries only samples, never the
+            ``.voc`` content, so the reference must be resolved here.
         """
         if not isinstance(filename, str):
             raise ValueError('Filename path must be a string')
@@ -314,6 +320,9 @@ class IntentServiceInterface:
         with open(filename) as f:
             samples = [_ for _ in f.read().split("\n") if _
                        and not _.startswith("#")]
+        if vocabs:
+            # OVOS-INTENT-1 §3.7: resolve every inline <name> in place
+            samples = [inline_keywords(s, vocabs) for s in samples]
         samples = _drop_malformed_samples(samples, intent_name, lang,
                                           self.skill_id)
         if not samples:

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -759,11 +759,13 @@ class SkillResources:
                     name = file_name[:-len(".voc")].lower()
                     if name in vocabularies:
                         continue
-                    members = []
+                    members: List[str] = []
                     with open(Path(directory, file_name)) as voc_file:
-                        for line in (ln.strip() for ln in voc_file):
+                        for line in (ln.strip().lower() for ln in voc_file):
                             if line and not line.startswith("#"):
-                                members.append(line.lower())
+                                # a .voc line MAY hold comma/parenthesis
+                                # alternates; every phrasing is a member
+                                members.extend(flatten_list(expand(line)))
                     if members:
                         vocabularies[name] = members
         return vocabularies
@@ -928,6 +930,20 @@ class SkillResources:
                     skill_vocabulary[vocab_type] = vocabulary
 
         return skill_vocabulary
+
+    def vocabularies(self) -> Dict[str, List[str]]:
+        """Build a ``{name: members}`` map from every ``.voc`` in this
+        language's locale tree.
+
+        Feeds the inline ``<name>`` resolution required by OVOS-INTENT-1 §3.7:
+        a reference in an ``.intent`` (or ``.blacklist``) expands in place from
+        the sibling vocabulary of that name. Padatious and padacioso never read
+        ``.voc`` files at match time, so the reference must be baked into the
+        template before it reaches the engine. User overrides take precedence
+        over the skill's own resources, which take precedence over
+        workshop-shipped resources.
+        """
+        return self._locale_vocabularies()
 
     def load_skill_regex(self, alphanumeric_skill_id: str) -> List[str]:
         """

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1365,9 +1365,12 @@ class OVOSSkill:
                 if phrases:
                     slot_blacklist[slot] = phrases
 
+            # OVOS-INTENT-1 §3.7: supply the sibling vocabularies so an inline
+            # <name> reference in the .intent is baked into the samples before
+            # they are sent to the engine over the bus
             self.intent_service.register_padatious_intent(
                 name, filename, lang, string_blacklist=disallowed_strings,
-                slot_blacklist=slot_blacklist)
+                slot_blacklist=slot_blacklist, vocabs=resources.vocabularies())
         if handler:
             self.add_event(name, handler, 'mycroft.skill.handler',
                            activation=True, is_intent=True)

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -19,7 +19,7 @@ import unittest
 from logging import Logger
 from threading import Event, Thread
 from time import time
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 from os.path import join, dirname, isdir
 from ovos_workshop.skills.ovos import OVOSSkill
 
@@ -443,7 +443,7 @@ class TestOVOSSkill(unittest.TestCase):
         skill.config_core["secondary_langs"] = []
         skill.register_intent_file("time.intent", Mock(__name__="test"))
         skill.intent_service.register_padatious_intent.assert_called_once_with(
-            f"{skill.skill_id}:time.intent", en_intent_file, "en-US", string_blacklist=[], slot_blacklist={})
+            f"{skill.skill_id}:time.intent", en_intent_file, "en-US", string_blacklist=[], slot_blacklist={}, vocabs=ANY)
 
         # With secondary language
         skill.intent_service.register_padatious_intent.reset_mock()
@@ -452,9 +452,9 @@ class TestOVOSSkill(unittest.TestCase):
         self.assertEqual(
             skill.intent_service.register_padatious_intent.call_count, 2)
         skill.intent_service.register_padatious_intent.assert_any_call(
-            f"{skill.skill_id}:time.intent", en_intent_file, "en-US", string_blacklist=[], slot_blacklist={})
+            f"{skill.skill_id}:time.intent", en_intent_file, "en-US", string_blacklist=[], slot_blacklist={}, vocabs=ANY)
         skill.intent_service.register_padatious_intent.assert_any_call(
-            f"{skill.skill_id}:time.intent", uk_intent_file, "uk-UA", string_blacklist=[], slot_blacklist={})
+            f"{skill.skill_id}:time.intent", uk_intent_file, "uk-UA", string_blacklist=[], slot_blacklist={}, vocabs=ANY)
 
     def test_register_entity_file(self):
         skill = OVOSSkill(bus=self.bus, skill_id=self.skill_id)

--- a/test/unittests/test_inline_vocab_refs.py
+++ b/test/unittests/test_inline_vocab_refs.py
@@ -1,12 +1,22 @@
+"""OVOS-INTENT-1 §3.7: an inline ``<name>`` reference in a ``.intent`` file is
+an authoring convenience that must expand in place from the sibling ``.voc`` of
+that name before the template reaches an intent engine. The padatious/padacioso
+bus protocol carries only samples — never the ``.voc`` content — so the
+reference has to be resolved during registration, otherwise the raw ``<name>``
+token is trained into the engine and the intent never matches."""
 import unittest
-from tempfile import TemporaryDirectory
 from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ovos_utils.fakebus import FakeBus
+from ovos_workshop.intents import IntentServiceInterface
+from ovos_workshop.resource_files import ResourceFile, SkillResources
 
 
 class TestInlineVocabReferences(unittest.TestCase):
-    """OVOS-INTENT-1 §3.7: an inline ``<name>`` reference in a ``.intent`` or
-    ``.blacklist`` file must expand in place from the sibling ``.voc`` of that
-    name found in the same locale directory."""
+    """The load-time resolution path: ``load_intent_file`` / ``load_blacklist_file``
+    expand every inline ``<name>`` from the sibling ``.voc`` of that name found in
+    the same locale directory."""
 
     def _skill_dir(self, files: dict) -> str:
         tmp = TemporaryDirectory()
@@ -18,7 +28,6 @@ class TestInlineVocabReferences(unittest.TestCase):
         return tmp.name
 
     def _resources(self, skill_dir):
-        from ovos_workshop.resource_files import SkillResources
         return SkillResources(skill_dir, "en-us", skill_id="test.skill")
 
     def test_intent_inline_vocab(self):
@@ -46,6 +55,115 @@ class TestInlineVocabReferences(unittest.TestCase):
         intents = self._resources(skill_dir).load_intent_file("foo.intent")
         self.assertIn("turn on the lamp", intents)
         self.assertIn("turn on the light", intents)
+
+
+class TestInlineVocabResources(unittest.TestCase):
+    def _resources(self, files):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        locale = Path(tmp.name, "locale", "en-us")
+        locale.mkdir(parents=True)
+        for name, content in files.items():
+            (locale / name).write_text(content)
+        return SkillResources(tmp.name, "en-us", skill_id="test.skill")
+
+    def test_vocabularies_map(self):
+        resources = self._resources({
+            "thing.voc": "widget\ngadget\n# comment\n",
+            "foo.intent": "what about <thing>\n",
+        })
+        self.assertEqual(resources.vocabularies().get("thing"),
+                         ["widget", "gadget"])
+
+    def test_vocabularies_expands_alternates(self):
+        resources = self._resources({
+            "greeting.voc": "(hello|hi)\ngood morning\n",
+        })
+        self.assertEqual(sorted(resources.vocabularies()["greeting"]),
+                         ["good morning", "hello", "hi"])
+
+
+class TestInlineVocabRegistration(unittest.TestCase):
+    """The samples emitted on the registration bus topic must already have the
+    inline ``<name>`` resolved to an ``(a|b|c)`` alternation group."""
+
+    def _capture_samples(self, files, pass_vocabs):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        locale = Path(tmp.name, "locale", "en-us")
+        locale.mkdir(parents=True)
+        for name, content in files.items():
+            (locale / name).write_text(content)
+        resources = SkillResources(tmp.name, "en-us", skill_id="test.skill")
+        filename = str(ResourceFile(resources.types.intent, "foo.intent").file_path)
+
+        bus = FakeBus()
+        captured = {}
+        bus.on("padatious:register_intent",
+               lambda m: captured.__setitem__("samples", m.data["samples"]))
+        iface = IntentServiceInterface(bus)
+        iface.set_id("test.skill")
+        kwargs = {"vocabs": resources.vocabularies()} if pass_vocabs else {}
+        iface.register_padatious_intent("test.skill:foo.intent", filename,
+                                        "en-us", **kwargs)
+        return captured["samples"]
+
+    def test_inline_reference_resolved_before_engine(self):
+        samples = self._capture_samples({
+            "thing.voc": "widget\ngadget\n",
+            "foo.intent": "what about <thing>\n",
+        }, pass_vocabs=True)
+        self.assertEqual(samples, ["what about (widget|gadget)"])
+
+    def test_raw_reference_without_vocabs_is_unresolved(self):
+        samples = self._capture_samples({
+            "thing.voc": "widget\ngadget\n",
+            "foo.intent": "what about <thing>\n",
+        }, pass_vocabs=False)
+        self.assertEqual(samples, ["what about <thing>"])
+
+
+class TestInlineVocabEngineEndToEnd(unittest.TestCase):
+    """End-to-end proof through the real engines: a skill shipping a ``foo.intent``
+    with ``<thing>`` and a sibling ``thing.voc`` matches an utterance built from a
+    vocabulary member, but only when the reference is resolved at registration."""
+
+    def _samples(self, pass_vocabs):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        locale = Path(tmp.name, "locale", "en-us")
+        locale.mkdir(parents=True)
+        (locale / "thing.voc").write_text("widget\ngadget\n")
+        (locale / "foo.intent").write_text("what about <thing>\n")
+        resources = SkillResources(tmp.name, "en-us", skill_id="test.skill")
+        filename = str(ResourceFile(resources.types.intent, "foo.intent").file_path)
+
+        bus = FakeBus()
+        captured = {}
+        bus.on("padatious:register_intent",
+               lambda m: captured.__setitem__("samples", m.data["samples"]))
+        iface = IntentServiceInterface(bus)
+        iface.set_id("test.skill")
+        kwargs = {"vocabs": resources.vocabularies()} if pass_vocabs else {}
+        iface.register_padatious_intent("test.skill:foo.intent", filename,
+                                        "en-us", **kwargs)
+        return captured["samples"]
+
+    def test_padacioso_inline_voc_intent_matches(self):
+        from padacioso import IntentContainer
+        engine = IntentContainer()
+        engine.add_intent("foo", self._samples(pass_vocabs=True))
+        self.assertEqual(engine.calc_intent("what about widget").get("name"),
+                         "foo")
+
+    def test_padacioso_raw_reference_is_rejected(self):
+        # an unresolved <thing> never reaches the engine as a matchable sample:
+        # padacioso cannot build an intent from the dangling reference
+        from padacioso import IntentContainer
+        from ovos_spec_tools.expansion import MalformedTemplate
+        engine = IntentContainer()
+        with self.assertRaises(MalformedTemplate):
+            engine.add_intent("foo", self._samples(pass_vocabs=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Per **OVOS-INTENT-1 §3.7**, an inline `<name>` reference in a `.intent` is an
authoring convenience that MUST expand in place from the sibling `.voc` of that
name **before** the template reaches an intent engine (`<name>` never reaches an
engine). Skills empirically found that a `.intent` shipping `<month>`/`<thing>`
plus a sibling `.voc` still failed to match — the engine trained on the literal
`<name>` token.

## Root cause

`OVOSSkill.register_intent_file` → `IntentServiceInterface.register_padatious_intent`
reads the raw `.intent` file and emits its lines as `samples` on the
`padatious:register_intent` bus topic. The bus protocol carries **only samples,
never the `.voc` content**, and no step resolved the inline reference, so the raw
`<name>` was trained into padatious/padacioso. (Workshop #455 fixed the separate
`SkillResources.load_intent_file` loader path, but that path is **not** used for
engine registration, so the pipeline stayed broken.)

Empirically, `what about <thing>` + `thing.voc` = `widget\ngadget`, utterance
`"what about widget"`:

| | samples sent to engine | padacioso | padatious |
|---|---|---|---|
| before | `what about <thing>` | **no match** | coincidental (0.54) |
| after | `what about (widget\|gadget)` | **match (1.0)** | **match (1.0)** |

## Fix

- `SkillResources.vocabularies()` builds the `{name: members}` map from the
  locale tree (user > skill > workshop precedence).
- `register_padatious_intent` gains a `vocabs` kwarg and inlines every `<name>`
  as an `(a|b|c)` group via `ovos_spec_tools.inline_keywords` before emitting the
  samples; `register_intent_file` supplies the map. Files without inline refs are
  unaffected.

## Tests

`test/unittests/test_inline_vocab_refs.py` — the `vocabularies()` map, the
resolved-vs-raw samples on the bus, and an **end-to-end match through the real
padacioso engine** (raw `<thing>` does not match; resolved does). TDD: the four
new-behavior tests fail on `dev`, all pass with the fix. Padatious verified
locally (fann2/libfann) with the same result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)