### PR TITLE
fix: require ovos-core with OVOS-CONTEXT-1 set_context mirror

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "ovos-core>=2.4.0a1",  # orchestrator owns ovos.utterance.handled on the matched path (PIPELINE-1 §9.5)
+    "ovos-core>=2.5.3a1",  # mirrors set_context into OVOS-CONTEXT-1 intent_context so IntentLayers gating matches (test_intent_layers_e2e)
     "ovoscope>=0.1.0",
     "ovos-adapt-parser>=1.4.2a1",
     "pytest",


### PR DESCRIPTION
## Why

`test/unittests/skills/test_intent_layers_e2e.py` is red on `dev`: an `IntentLayers`-gated step intent that should match returns `None`. Root cause is **not** in ovos-workshop — the CONTEXT-1-migrated adapt pipeline gates/injects context from `session.intent_context`, but `skill.set_context()` (via ovos-core's `add_context`/`remove_context` handlers) only maintained the legacy frame-stack `session.context`. So the layer token never reached matching.

The fix lives in ovos-core: **OpenVoiceOS/ovos-core#804** mirrors `set_context` into `session.intent_context`. The `IntentLayers` implementation here needs no change (a skill-side write can't survive the wholesale session fold; it must be done server-side).

## Change

Floor-pin the `[test]` extra to the ovos-core release carrying the mirror (`>=2.5.1a1`). This unblocks the intent-layers e2e (and therefore any workshop PR whose `build_tests` were red on those 2 tests, e.g. #458).

> Blocked on ovos-core#804 merging and its alpha publishing. Kept as draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)