### PR TITLE
Echo fallback request ids

### DIFF
--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -111,10 +111,21 @@ class FallbackSkill(OVOSSkill):
         """
         Inform skills service we can handle fallbacks.
         """
+        request_id = (
+            message.data.get("fallback_request_id")
+            or message.context.get("fallback_request_id")
+        )
+        data = {
+            "skill_id": self.skill_id,
+            "can_handle": self.can_answer(message),
+        }
+        context = {"skill_id": self.skill_id}
+        if request_id:
+            data["fallback_request_id"] = request_id
+            context["fallback_request_id"] = request_id
         self.bus.emit(message.reply("ovos.skills.fallback.pong",
-                                    data={"skill_id": self.skill_id,
-                                          "can_handle": self.can_answer(message)},
-                                    context={"skill_id": self.skill_id}))
+                                    data=data,
+                                    context=context))
 
     def _on_timeout(self):
         """_handle_fallback_request timed out and was forcefully killed by ovos-core"""

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import abc
 import operator
-from typing import Callable, Optional, List
+from typing import Callable, Optional
 
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_config import Configuration

--- a/test/unittests/test_fallback_skill.py
+++ b/test/unittests/test_fallback_skill.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from ovos_workshop.skills.fallback import FallbackSkill
+
+
+def _make_skill():
+    skill = FallbackSkill.__new__(FallbackSkill)
+    skill.skill_id = "test.skill"
+    skill.bus = FakeBus()
+    skill.bus.emit = MagicMock()
+    skill.can_answer = MagicMock(return_value=True)
+    return skill
+
+
+def test_fallback_ack_echoes_request_id():
+    skill = _make_skill()
+
+    skill._handle_fallback_ack(Message(
+        "ovos.skills.fallback.ping",
+        {"fallback_request_id": "req-1"},
+        {"fallback_request_id": "req-1"},
+    ))
+
+    emitted = skill.bus.emit.call_args[0][0]
+    assert emitted.msg_type == "ovos.skills.fallback.pong"
+    assert emitted.data["skill_id"] == "test.skill"
+    assert emitted.data["can_handle"] is True
+    assert emitted.data["fallback_request_id"] == "req-1"
+    assert emitted.context["fallback_request_id"] == "req-1"
+
+
+def test_fallback_ack_keeps_legacy_shape_without_request_id():
+    skill = _make_skill()
+
+    skill._handle_fallback_ack(Message("ovos.skills.fallback.ping"))
+
+    emitted = skill.bus.emit.call_args[0][0]
+    assert emitted.msg_type == "ovos.skills.fallback.pong"
+    assert emitted.data == {"skill_id": "test.skill", "can_handle": True}
+    assert emitted.context == {"skill_id": "test.skill"}


### PR DESCRIPTION
## What
- echo `fallback_request_id` on fallback pong data/context when present
- keep the old pong shape when the request id is absent

## Why
ovos-core can now scope fallback candidate collection per request. Fallback skills need to carry that id back so concurrent fallback pings do not bleed into each other.

## Test
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/unittests/test_fallback_skill.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fallback acknowledgements now include a request ID when available, making request/response tracking more reliable.
  * If no request ID is present, the previous message format remains unchanged for compatibility.
* **Tests**
  * Added coverage for fallback acknowledgement messages with and without a request ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->