### PR TITLE
Use FALLBACK-1 skill-addressed ping and pong topics

### DIFF
--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import abc
 import operator
-from typing import Callable, Optional, List
+from typing import Callable, Optional
 
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_config import Configuration
@@ -103,7 +103,8 @@ class FallbackSkill(OVOSSkill):
         fallback skill.
         """
         super()._register_system_event_handlers()
-        self.add_event('ovos.skills.fallback.ping', self._handle_fallback_ack, speak_errors=False)
+        self.add_event(f"{self.skill_id}.fallback.ping",
+                       self._handle_fallback_ack, speak_errors=False)
         self.add_event(f"ovos.skills.fallback.{self.skill_id}.request", self._handle_fallback_request,
                        speak_errors=False)
 
@@ -111,7 +112,7 @@ class FallbackSkill(OVOSSkill):
         """
         Inform skills service we can handle fallbacks.
         """
-        self.bus.emit(message.reply("ovos.skills.fallback.pong",
+        self.bus.emit(message.reply(f"{self.skill_id}.fallback.pong",
                                     data={"skill_id": self.skill_id,
                                           "can_handle": self.can_answer(message)},
                                     context={"skill_id": self.skill_id}))

--- a/test/unittests/skills/test_fallback_skill.py
+++ b/test/unittests/skills/test_fallback_skill.py
@@ -69,19 +69,27 @@ class TestFallbackSkillV2(TestCase):
                              in tup for tup in self.fallback_skill.events]))
 
     def test_handle_fallback_ack(self):
+        received = Event()
+
         def mock_pong(message: Message):
             self.assertEqual(message.data["skill_id"],
                              self.fallback_skill.skill_id)
             self.assertEqual(message.context["skill_id"],
                              self.fallback_skill.skill_id)
             self.assertEqual(message.data["can_handle"], "test")
+            received.set()
         
         orig_can_answer = self.fallback_skill.can_answer
         self.fallback_skill.can_answer = Mock(return_value="test")
         self.fallback_skill.bus.once(
             f"{self.fallback_skill.skill_id}.fallback.pong", mock_pong)
 
-        self.fallback_skill._handle_fallback_ack(Message("test"))
+        self.fallback_skill.bus.emit(Message(
+            f"{self.fallback_skill.skill_id}.fallback.ping",
+            {"utterances": ["hello"], "lang": "en-US"},
+        ))
+        self.assertTrue(received.wait(0.5))
+        self.fallback_skill.can_answer.assert_called_once()
         self.fallback_skill.can_answer = orig_can_answer
         
 

--- a/test/unittests/skills/test_fallback_skill.py
+++ b/test/unittests/skills/test_fallback_skill.py
@@ -1,6 +1,6 @@
 import time
 from unittest import TestCase
-from unittest.mock import patch, Mock
+from unittest.mock import Mock
 
 from threading import Event
 from ovos_utils.fakebus import FakeBus
@@ -63,7 +63,7 @@ class TestFallbackSkillV2(TestCase):
         self.assertFalse(self.fallback_skill.can_answer(Message("")))
 
     def test_register_system_event_handlers(self):
-        self.assertTrue(any(["ovos.skills.fallback.ping" in tup
+        self.assertTrue(any([f"{self.fallback_skill.skill_id}.fallback.ping" in tup
                              for tup in self.fallback_skill.events]))
         self.assertTrue(any([f"ovos.skills.fallback.{self.fallback_skill.skill_id}.request"
                              in tup for tup in self.fallback_skill.events]))
@@ -78,7 +78,8 @@ class TestFallbackSkillV2(TestCase):
         
         orig_can_answer = self.fallback_skill.can_answer
         self.fallback_skill.can_answer = Mock(return_value="test")
-        self.fallback_skill.bus.once("ovos.skills.fallback.pong", mock_pong)
+        self.fallback_skill.bus.once(
+            f"{self.fallback_skill.skill_id}.fallback.pong", mock_pong)
 
         self.fallback_skill._handle_fallback_ack(Message("test"))
         self.fallback_skill.can_answer = orig_can_answer
@@ -131,7 +132,7 @@ class TestFallbackSkillV2(TestCase):
             return True
             
         self.fallback_skill.bus.once(
-            f"ovos.skills.fallback.register", fallback_service_register
+            "ovos.skills.fallback.register", fallback_service_register
         )
         self.fallback_skill.register_fallback(mock_handler, priority)
         self.assertEqual(len(self.fallback_skill._fallback_handlers), 1)
@@ -154,7 +155,7 @@ class TestFallbackSkillV2(TestCase):
         
         deregister_event = Event()
         self.fallback_skill.bus.once(
-            f"ovos.skills.fallback.deregister", fallback_service_deregister
+            "ovos.skills.fallback.deregister", fallback_service_deregister
         )
         self.fallback_skill._fallback_handlers = [(50, mock_handler)]
         self.assertEqual(len(self.fallback_skill._fallback_handlers), 1)
@@ -165,7 +166,7 @@ class TestFallbackSkillV2(TestCase):
         self.assertFalse(deregister_event.is_set())
 
         self.fallback_skill.bus.once(
-            f"ovos.skills.fallback.deregister", fallback_service_deregister
+            "ovos.skills.fallback.deregister", fallback_service_deregister
         )
         self.fallback_skill._fallback_handlers = [(100, mock_handler), (50, mock_handler)]
         self.fallback_skill.remove_fallback()


### PR DESCRIPTION
Fixes #464 by removing the shared fallback-pong channel that made request-level echoing necessary.

## Architecture

- Register each fallback skill on `<skill_id>.fallback.ping`.
- Reply on the matching `<skill_id>.fallback.pong` topic.
- Remove those exact handlers during shutdown.

This is the skill-side half of OpenVoiceOS/ovos-core#808. It follows the FALLBACK-1 topic contract directly and keeps traffic owned by the fallback skill; it does not add request IDs, a compatibility bridge, or a generic agent hook.

## Validation

- 11 focused fallback-skill tests pass.
- The companion Core fallback suite passes against this local package.
- Ruff passes.
- All GitHub checks and CodeRabbit pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback skill communication by using skill-specific events for ping and pong messages.
  * Enhanced asynchronous handling to ensure fallback responses are delivered reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->