### PR TITLE
fix: skip malformed template lines instead of failing the whole resource

### DIFF
--- a/ovos_workshop/intents.py
+++ b/ovos_workshop/intents.py
@@ -1,3 +1,4 @@
+import re
 from os.path import exists
 from threading import RLock
 from typing import Dict, List, Optional
@@ -12,6 +13,32 @@ from ovos_utils.log import LOG, log_deprecation
 # the single source of truth is the spec. The `IntentServiceInterface` producer
 # (and the munge_* helpers) below consume these definitions.
 from ovos_spec_tools import Intent, IntentBuilder, open_intent_envelope
+from ovos_spec_tools import expand, MalformedTemplate
+
+
+def _drop_malformed_samples(samples: List[str], name: str, lang: str,
+                            skill_id: str) -> List[str]:
+    """Filter out sample lines that are not valid OVOS-INTENT-1 templates.
+
+    Locale files sometimes carry broken template lines — translated slot
+    names, truncated or adjacent slots. A single such line must not prevent
+    the remaining valid lines from being registered, so each malformed line
+    is skipped with a warning instead of aborting the registration.
+
+    ``<name>`` vocabulary references resolve downstream at match time, so
+    they are replaced by a literal placeholder for validation only; the
+    emitted samples keep the original lines.
+    """
+    valid = []
+    for sample in samples:
+        try:
+            expand(re.sub(r"<\s*([a-z0-9_]+)\s*>", "placeholder", sample))
+            valid.append(sample)
+        except MalformedTemplate as err:
+            LOG.warning(f"Skipping malformed template line in '{name}' "
+                        f"(skill_id={skill_id}, lang={lang}): "
+                        f"{sample!r} ({err})")
+    return valid
 
 
 def to_alnum(skill_id: str) -> str:
@@ -291,6 +318,13 @@ class IntentServiceInterface:
         with open(filename) as f:
             samples = [_ for _ in f.read().split("\n") if _
                        and not _.startswith("#")]
+        samples = _drop_malformed_samples(samples, intent_name, lang,
+                                          self.skill_id)
+        if not samples:
+            LOG.warning(f"Not registering intent '{intent_name}' "
+                        f"(skill_id={self.skill_id}, lang={lang}): "
+                        f"no valid template lines in {filename}")
+            return
         data = {'file_name': filename,
                 "samples": samples,
                 'name': intent_name,
@@ -323,6 +357,13 @@ class IntentServiceInterface:
         with open(filename) as f:
             samples = [_ for _ in f.read().split("\n") if _
                        and not _.startswith("#")]
+        samples = _drop_malformed_samples(samples, entity_name, lang,
+                                          self.skill_id)
+        if not samples:
+            LOG.warning(f"Not registering entity '{entity_name}' "
+                        f"(skill_id={self.skill_id}, lang={lang}): "
+                        f"no valid template lines in {filename}")
+            return
         msg = dig_for_message() or Message("")
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id

--- a/ovos_workshop/intents.py
+++ b/ovos_workshop/intents.py
@@ -12,22 +12,18 @@ from ovos_utils.log import LOG, log_deprecation
 # their long-standing `from ovos_workshop.intents import IntentBuilder` import while
 # the single source of truth is the spec. The `IntentServiceInterface` producer
 # (and the munge_* helpers) below consume these definitions.
-from ovos_spec_tools import Intent, IntentBuilder, open_intent_envelope
-from ovos_spec_tools import expand, MalformedTemplate
+from ovos_spec_tools import (Intent, IntentBuilder, open_intent_envelope,
+                             expand, MalformedTemplate)
 
 
 def _drop_malformed_samples(samples: List[str], name: str, lang: str,
                             skill_id: str) -> List[str]:
-    """Filter out sample lines that are not valid OVOS-INTENT-1 templates.
+    """Skip-and-warn sample lines that are not valid OVOS-INTENT-1 templates,
+    so one broken locale line cannot abort the whole registration.
 
-    Locale files sometimes carry broken template lines — translated slot
-    names, truncated or adjacent slots. A single such line must not prevent
-    the remaining valid lines from being registered, so each malformed line
-    is skipped with a warning instead of aborting the registration.
-
-    ``<name>`` vocabulary references resolve downstream at match time, so
-    they are replaced by a literal placeholder for validation only; the
-    emitted samples keep the original lines.
+    ``<name>`` vocabulary references resolve downstream at match time; they
+    are replaced by a literal placeholder for validation only, and the
+    returned samples keep the original lines.
     """
     valid = []
     for sample in samples:

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -25,8 +25,7 @@ from typing import List, Optional, Tuple, Dict, Any
 from langcodes import tag_distance
 from ovos_config.locations import get_xdg_data_save_path
 from ovos_utils import flatten_list
-from ovos_utils.bracket_expansion import expand_template
-from ovos_spec_tools import inline_keywords
+from ovos_spec_tools import expand, inline_keywords, MalformedTemplate
 from ovos_utils.dialog import MustacheDialogRenderer, load_dialogs
 from ovos_utils.log import LOG
 
@@ -279,7 +278,21 @@ class ResourceFile:
     def __init__(self, resource_type: ResourceType, resource_name: str):
         self.resource_type = resource_type
         self.resource_name = resource_name
+        # set by SkillResources so per-line warnings can identify the skill
+        self.skill_id = None
         self.file_path = self._locate()
+
+    def _warn_malformed_line(self, line: str, error: Exception):
+        """Log a malformed template line that is being skipped.
+
+        A single broken line (e.g. a translated slot name or a truncated
+        slot in one language's locale file) must not prevent the remaining
+        valid lines of the resource from loading.
+        """
+        LOG.warning(
+            f"Skipping malformed template line in {self.file_path} "
+            f"(skill_id={self.skill_id}, resource={self.resource_name}, "
+            f"lang={self.resource_type.language}): {line!r} ({error})")
 
     def _locate(self) -> Optional[str]:
         """Locates a resource file in the skill's locale directory.
@@ -398,7 +411,11 @@ class DialogFile(ResourceFile):
             for line in self._read():
                 line = line.replace("{{", "{").replace("}}", "}")
                 if self.data is not None:
-                    line = line.format(**self.data)
+                    try:
+                        line = line.format(**self.data)
+                    except (KeyError, IndexError, ValueError) as err:
+                        self._warn_malformed_line(line, err)
+                        continue
                 dialogs.append(line)
 
         return dialogs
@@ -433,7 +450,10 @@ class VocabularyFile(ResourceFile):
         vocabulary = []
         if self.file_path is not None:
             for line in self._read():
-                vocabulary.append(expand_template(line.lower()))
+                try:
+                    vocabulary.append(expand(line.lower()))
+                except MalformedTemplate as err:
+                    self._warn_malformed_line(line, err)
         return vocabulary
 
 
@@ -459,15 +479,25 @@ class IntentFile(ResourceFile):
         if self.file_path is not None:
             for line in self._read():
                 line = line.replace("{{", "{").replace("}}", "}").lower()
-                if self.vocabularies and "<" in line:
-                    # OVOS-INTENT-1 §3.7: inline every <name> reference from the
-                    # sibling vocabulary as an (a|b|c) group before expanding.
-                    line = inline_keywords(line, self.vocabularies)
-                intents.extend(flatten_list(expand_template(line)))
+                try:
+                    if self.vocabularies and "<" in line:
+                        # OVOS-INTENT-1 §3.7: inline every <name> reference
+                        # from the sibling vocabulary as an (a|b|c) group
+                        # before expanding.
+                        line = inline_keywords(line, self.vocabularies)
+                    intents.extend(flatten_list(expand(line)))
+                except MalformedTemplate as err:
+                    self._warn_malformed_line(line, err)
             if not entities:
                 intents = [re.sub(r'{.*?}\s?', '', intent).strip() for intent in intents]
             elif self.data:
-                intents = [intent.format(**self.data) for intent in intents]
+                formatted = []
+                for intent in intents:
+                    try:
+                        formatted.append(intent.format(**self.data))
+                    except (KeyError, IndexError, ValueError) as err:
+                        self._warn_malformed_line(intent, err)
+                intents = formatted
         return intents
 
     def render(self, dialog_renderer):
@@ -582,8 +612,11 @@ class BlacklistFile(ResourceFile):
                 if self.vocabularies and "<" in line:
                     # OVOS-INTENT-1 §3.7: inline every <name> reference from the
                     # sibling vocabulary and enumerate the resulting phrases.
-                    line = inline_keywords(line, self.vocabularies)
-                    phrases.extend(flatten_list(expand_template(line)))
+                    try:
+                        line = inline_keywords(line, self.vocabularies)
+                        phrases.extend(flatten_list(expand(line)))
+                    except MalformedTemplate as err:
+                        self._warn_malformed_line(line, err)
                 else:
                     phrases.append(line)
         return phrases
@@ -679,6 +712,7 @@ class SkillResources:
             A list of phrases with variables resolved
         """
         dialog_file = DialogFile(self.types.dialog, name)
+        dialog_file.skill_id = self.skill_id
         dialog_file.data = data
         return dialog_file.load()
 
@@ -701,6 +735,7 @@ class SkillResources:
             A list of intent phrases
         """
         intent_file = IntentFile(self.types.intent, name)
+        intent_file.skill_id = self.skill_id
         intent_file.data = data
         intent_file.vocabularies = self._locale_vocabularies()
         return intent_file.load(entities)
@@ -750,6 +785,7 @@ class SkillResources:
             A list of blacklisted phrases
         """
         blacklist_file = BlacklistFile(self.types.blacklist, name)
+        blacklist_file.skill_id = self.skill_id
         blacklist_file.vocabularies = self._locale_vocabularies()
         return blacklist_file.load()
 
@@ -848,6 +884,7 @@ class SkillResources:
             List representation of the regular expression file.
         """
         vocabulary_file = VocabularyFile(self.types.vocabulary, name)
+        vocabulary_file.skill_id = self.skill_id
         return vocabulary_file.load()
 
     def load_word_file(self, name: str) -> Optional[str]:

--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -283,12 +283,8 @@ class ResourceFile:
         self.file_path = self._locate()
 
     def _warn_malformed_line(self, line: str, error: Exception):
-        """Log a malformed template line that is being skipped.
-
-        A single broken line (e.g. a translated slot name or a truncated
-        slot in one language's locale file) must not prevent the remaining
-        valid lines of the resource from loading.
-        """
+        """Log a malformed template line that is skipped so the rest of the
+        resource can still load."""
         LOG.warning(
             f"Skipping malformed template line in {self.file_path} "
             f"(skill_id={self.skill_id}, resource={self.resource_name}, "

--- a/test/unittests/test_malformed_template_resilience.py
+++ b/test/unittests/test_malformed_template_resilience.py
@@ -1,0 +1,169 @@
+"""A malformed template line in a locale file must not prevent the valid
+lines of the same file from loading or reaching the intent service.
+
+Translated locale files sometimes carry broken templates — translated slot
+names (``{Medien}``), truncated slots (``{location``), adjacent slots — and
+one such line must be skipped with a warning, not abort the whole resource.
+"""
+import unittest
+from os.path import join
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from ovos_workshop.intents import IntentServiceInterface
+from ovos_workshop.resource_files import SkillResources
+
+
+class MockEmitter:
+    def __init__(self):
+        self.messages = []
+
+    def emit(self, message):
+        self.messages.append(message)
+
+
+class TestResourceLoadResilience(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.skill_dir = self._tmp.name
+        self.locale = join(self.skill_dir, "locale", "de-de")
+        import os
+        os.makedirs(self.locale)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, name, lines):
+        path = join(self.locale, name)
+        with open(path, "w") as f:
+            f.write("\n".join(lines))
+        return path
+
+    def _resources(self):
+        return SkillResources(self.skill_dir, "de-de", skill_id="test.skill")
+
+    def test_intent_file_skips_malformed_lines(self):
+        self._write("play.intent", ["spiele {media}",
+                                    "spiele {genre}{media}",   # adjacent slots
+                                    "was läuft in {location",  # truncated slot
+                                    "starte {media}"])
+        with patch("ovos_workshop.resource_files.LOG.warning") as warn:
+            intents = self._resources().load_intent_file("play")
+        self.assertEqual(intents, ["spiele {media}", "starte {media}"])
+        self.assertEqual(warn.call_count, 2)
+        logged = " ".join(str(c) for c in warn.call_args_list)
+        self.assertIn("test.skill", logged)
+        self.assertIn("play", logged)
+        self.assertIn("de-de", logged)
+        self.assertIn("{location", logged)
+
+    def test_intent_file_all_lines_malformed(self):
+        self._write("play.intent", ["spiele {genre}{media}", "in {location"])
+        with patch("ovos_workshop.resource_files.LOG.warning"):
+            intents = self._resources().load_intent_file("play")
+        self.assertEqual(intents, [])
+
+    def test_vocabulary_file_skips_malformed_lines(self):
+        self._write("media.voc", ["musik", "(radio|fernsehen", "film"])
+        with patch("ovos_workshop.resource_files.LOG.warning") as warn:
+            vocab = self._resources().load_vocabulary_file("media")
+        self.assertEqual(vocab, [["musik"], ["film"]])
+        self.assertEqual(warn.call_count, 1)
+
+    def test_blacklist_file_skips_malformed_lines(self):
+        self._write("thing.voc", ["dies", "das"])
+        self._write("play.blacklist", ["spiele <thing> ab",
+                                       "spiele <thing> (etwas|",
+                                       "halt"])
+        with patch("ovos_workshop.resource_files.LOG.warning") as warn:
+            phrases = self._resources().load_blacklist_file("play")
+        self.assertEqual(sorted(phrases),
+                         sorted(["spiele dies ab", "spiele das ab", "halt"]))
+        self.assertEqual(warn.call_count, 1)
+
+    def test_dialog_file_skips_lines_missing_data_keys(self):
+        self._write("play.dialog", ["spiele {media}", "spiele {Medien}"])
+        with patch("ovos_workshop.resource_files.LOG.warning") as warn:
+            dialogs = self._resources().load_dialog_file(
+                "play", data={"media": "musik"})
+        self.assertEqual(dialogs, ["spiele musik"])
+        self.assertEqual(warn.call_count, 1)
+
+
+class TestWireEmissionResilience(unittest.TestCase):
+    """The samples emitted on the bus must exclude malformed lines."""
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.emitter = MockEmitter()
+        self.interface = IntentServiceInterface(self.emitter)
+        self.interface.set_id("test.skill")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, name, lines):
+        path = join(self._tmp.name, name)
+        with open(path, "w") as f:
+            f.write("\n".join(lines))
+        return path
+
+    def test_register_intent_excludes_malformed_samples(self):
+        path = self._write("play.intent", ["play {media}",
+                                           "play {Medien}",
+                                           "what is on {location",
+                                           "start {media}"])
+        with patch("ovos_workshop.intents.LOG.warning") as warn:
+            self.interface.register_padatious_intent(
+                "test.skill:play.intent", path, "de-de")
+        self.assertEqual(len(self.emitter.messages), 1)
+        msg = self.emitter.messages[0]
+        self.assertEqual(msg.msg_type, "padatious:register_intent")
+        self.assertEqual(msg.data["samples"],
+                         ["play {media}", "start {media}"])
+        self.assertEqual(warn.call_count, 2)
+        logged = " ".join(str(c) for c in warn.call_args_list)
+        self.assertIn("test.skill", logged)
+        self.assertIn("play.intent", logged)
+        self.assertIn("de-de", logged)
+        self.assertIn("{Medien}", logged)
+
+    def test_register_intent_keeps_vocab_references(self):
+        # <name> references resolve downstream; they are not malformed
+        path = self._write("play.intent", ["play <thing>", "play {Medien}"])
+        with patch("ovos_workshop.intents.LOG.warning"):
+            self.interface.register_padatious_intent(
+                "test.skill:play.intent", path, "en-US")
+        self.assertEqual(self.emitter.messages[0].data["samples"],
+                         ["play <thing>"])
+
+    def test_register_intent_skipped_when_no_valid_samples(self):
+        path = self._write("play.intent", ["play {Medien}", "on {location"])
+        with patch("ovos_workshop.intents.LOG.warning") as warn:
+            self.interface.register_padatious_intent(
+                "test.skill:play.intent", path, "de-de")
+        self.assertEqual(self.emitter.messages, [])
+        self.assertNotIn("play.intent", self.interface.intent_names)
+        self.assertTrue(warn.call_count >= 3)
+
+    def test_register_entity_excludes_malformed_samples(self):
+        path = self._write("thing.entity", ["a movie", "ein (film|",
+                                            "a song"])
+        with patch("ovos_workshop.intents.LOG.warning") as warn:
+            self.interface.register_padatious_entity(
+                "test.skill:thing", path, "de-de")
+        self.assertEqual(len(self.emitter.messages), 1)
+        self.assertEqual(self.emitter.messages[0].data["samples"],
+                         ["a movie", "a song"])
+        self.assertEqual(warn.call_count, 1)
+
+    def test_register_entity_skipped_when_no_valid_samples(self):
+        path = self._write("thing.entity", ["ein (film|"])
+        with patch("ovos_workshop.intents.LOG.warning"):
+            self.interface.register_padatious_entity(
+                "test.skill:thing", path, "de-de")
+        self.assertEqual(self.emitter.messages, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_malformed_template_resilience.py
+++ b/test/unittests/test_malformed_template_resilience.py
@@ -5,6 +5,7 @@ Translated locale files sometimes carry broken templates — translated slot
 names (``{Medien}``), truncated slots (``{location``), adjacent slots — and
 one such line must be skipped with a warning, not abort the whole resource.
 """
+import os
 import unittest
 from os.path import join
 from tempfile import TemporaryDirectory
@@ -27,7 +28,6 @@ class TestResourceLoadResilience(unittest.TestCase):
         self._tmp = TemporaryDirectory()
         self.skill_dir = self._tmp.name
         self.locale = join(self.skill_dir, "locale", "de-de")
-        import os
         os.makedirs(self.locale)
 
     def tearDown(self):


### PR DESCRIPTION
## Summary

A single malformed template line in a skill's locale file — a translated slot name (`{Medien}`), a truncated slot (`{location`), adjacent slots, or an unbalanced group — raised `MalformedTemplate` during resource loading / intent registration. The exception aborted the whole file, so every valid line was lost and the intent was never registered for that language.

## Changes

- `ovos_workshop/resource_files.py`: `IntentFile`, `VocabularyFile` and `BlacklistFile` now expand each line individually; a malformed line is skipped with a warning (skill id, resource name, language, offending line) and the remaining lines load normally. `DialogFile` and the `IntentFile` data-formatting step likewise skip lines whose placeholders cannot be resolved. The deprecated `expand_template` import is replaced by `ovos_spec_tools.expand`.
- `ovos_workshop/intents.py`: `register_padatious_intent` / `register_padatious_entity` validate each sample before emitting the registration message, so the wire payload excludes malformed lines. When no valid lines remain the registration is skipped with a warning instead of raising. Inline `<name>` vocabulary references are preserved — they resolve downstream at match time.

## Tests

`test/unittests/test_malformed_template_resilience.py` covers .intent, .voc, .blacklist, .dialog loading and the padatious intent/entity bus emission, including the zero-valid-lines case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)