### PR TITLE
fix: replay intent registrations when matchers lose compiled state

### DIFF
--- a/ovos_workshop/intents.py
+++ b/ovos_workshop/intents.py
@@ -107,6 +107,9 @@ class IntentServiceInterface:
         # TODO: Consider using properties with setters to prevent duplicates
         self.registered_intents: List[Tuple[str, object]] = []
         self.detached_intents: List[Tuple[str, object]] = []
+        # registration payloads recorded for replay (reregister_all)
+        self.registered_vocab: List[dict] = []
+        self.registered_entities: List[dict] = []
         self._iterator_lock = RLock()
 
     @property
@@ -154,8 +157,9 @@ class IntentServiceInterface:
                        'lang': lang}
         compatibility_data = {'start': entity, 'end': vocab_type}
 
-        self.bus.emit(msg.forward("register_vocab",
-                                  {**entity_data, **compatibility_data}))
+        payload = {**entity_data, **compatibility_data}
+        self.registered_vocab.append(payload)
+        self.bus.emit(msg.forward("register_vocab", payload))
         for alias in aliases:
             alias_data = {
                 'entity_value': alias,
@@ -163,8 +167,9 @@ class IntentServiceInterface:
                 'alias_of': entity,
                 'lang': lang}
             compatibility_data = {'start': alias, 'end': vocab_type}
-            self.bus.emit(msg.forward("register_vocab",
-                                      {**alias_data, **compatibility_data}))
+            payload = {**alias_data, **compatibility_data}
+            self.registered_vocab.append(payload)
+            self.bus.emit(msg.forward("register_vocab", payload))
 
     def register_adapt_regex(self, regex: str, lang: str = None):
         """
@@ -176,8 +181,9 @@ class IntentServiceInterface:
         msg = dig_for_message() or Message("")
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id
-        self.bus.emit(msg.forward("register_vocab",
-                                  {'regex': regex, 'lang': lang}))
+        payload = {'regex': regex, 'lang': lang}
+        self.registered_vocab.append(payload)
+        self.bus.emit(msg.forward("register_vocab", payload))
 
     def register_adapt_intent(self, name: str, intent_parser: object):
         """
@@ -326,12 +332,51 @@ class IntentServiceInterface:
         msg = dig_for_message() or Message("")
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id
-        self.bus.emit(msg.forward('padatious:register_entity',
-                                  {'file_name': filename,
-                                   "samples": samples,
-                                   'name': entity_name,
-                                   'lang': lang,
-                                   'blacklist': blacklist or []}))
+        payload = {'file_name': filename,
+                   "samples": samples,
+                   'name': entity_name,
+                   'lang': lang,
+                   'blacklist': blacklist or []}
+        self.registered_entities.append(payload)
+        self.bus.emit(msg.forward('padatious:register_entity', payload))
+
+    def reregister_all(self):
+        """
+        Re-emit every recorded registration currently in effect.
+
+        The intent matchers hold registrations in memory, built from
+        registration broadcasts. Those broadcasts are load-time announcements
+        (OVOS-INTENT-4 §10): a matcher (re)constructed after this skill loaded
+        has missed them and matches nothing until they are replayed.
+        Re-registration is implicit replacement (OVOS-INTENT-4 §8.1), so
+        replaying is safe even for a matcher that never lost them. Detached
+        intents are not replayed and stay detached.
+        """
+        msg = dig_for_message() or Message("")
+        if "skill_id" not in msg.context:
+            msg.context["skill_id"] = self.skill_id
+        # vocabulary/entities first so intents never reference a keyword the
+        # matcher has not (re)learned yet
+        for payload in list(self.registered_vocab):
+            self.bus.emit(msg.forward("register_vocab", payload))
+        for payload in list(self.registered_entities):
+            self.bus.emit(msg.forward("padatious:register_entity", payload))
+        with self._iterator_lock:
+            snapshot = list(self.registered_intents)
+        for name, intent in snapshot:
+            if isinstance(intent, dict):
+                # padatious consumers key intents by name and retrain, so a
+                # plain re-register replaces any previous definition
+                self.bus.emit(msg.forward("padatious:register_intent", intent))
+            else:
+                # legacy adapt consumers append parsers instead of replacing;
+                # detach first so the replay can never duplicate the parser
+                full_name = getattr(intent, "name",
+                                    f"{self.skill_id}:{name}")
+                self.bus.emit(msg.forward("detach_intent",
+                                          {"intent_name": full_name}))
+                self.bus.emit(msg.forward("register_intent",
+                                          intent.__dict__))
 
     def get_intent_names(self):
         log_deprecation("Reference `intent_names` directly", "0.1.0")
@@ -353,6 +398,8 @@ class IntentServiceInterface:
             LOG.error(f"Expected an empty list; got: {self.registered_intents}")
             self.registered_intents = []
         self.detached_intents = []  # Explicitly remove all intent references
+        self.registered_vocab = []
+        self.registered_entities = []
 
     def get_intent(self, intent_name: str) -> Optional[object]:
         """

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -176,6 +176,18 @@ class FallbackSkill(OVOSSkill):
                               {"skill_id": self.skill_id,
                                "priority": self.priority}))
 
+    def _re_register_intents(self):
+        """
+        Replay registrations after the matchers lost compiled state — the
+        fallback registration lives in the fallback matcher's memory just
+        like intents do, so it is replayed alongside them.
+        """
+        super()._re_register_intents()
+        if self._fallback_handlers:
+            self.bus.emit(Message("ovos.skills.fallback.register",
+                                  {"skill_id": self.skill_id,
+                                   "priority": self.priority}))
+
     def remove_fallback(self, handler_to_del: Optional[callable] = None) -> bool:
         """
         Remove fallback registration / fallback handler.

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1116,6 +1116,42 @@ class OVOSSkill:
         # homescreen might load after this skill and miss the original events
         self.add_event("homescreen.metadata.get", self.handle_homescreen_loaded, speak_errors=False)
 
+        # the intent matchers might (re)load after this skill and miss the
+        # original registration broadcasts (OVOS-INTENT-4 §10 — load-time
+        # announcements with no catch-up channel); replay them on request
+        self.add_event("intent.service.pipelines.loaded",
+                       self._handle_intents_reset, speak_errors=False)
+        # a messagebus restart drops and re-opens the websocket; replay so a
+        # matcher that (re)started while this process was disconnected can
+        # never be left without this skill's registrations
+        self.bus.on("open", self._handle_bus_reconnect)
+
+    def _handle_intents_reset(self, message: Optional[Message] = None):
+        """
+        The intent service (re)loaded its pipeline plugins; freshly
+        constructed matchers have empty compiled state, replay this skill's
+        registrations so its intents keep matching.
+        """
+        self._re_register_intents()
+
+    def _handle_bus_reconnect(self, *_):
+        """
+        The websocket to the messagebus was re-established after a drop.
+        """
+        self._re_register_intents()
+
+    def _re_register_intents(self):
+        """
+        Replay every intent/vocabulary registration currently in effect.
+        Re-registration is implicit replacement (OVOS-INTENT-4 §8.1), so this
+        is safe for matchers that never lost the originals.
+        """
+        if not self._init_event.is_set():
+            # initial registration still in progress; nothing to replay
+            return
+        self.log.info(f"re-registering intents for {self.skill_id}")
+        self.intent_service.reregister_all()
+
     def _send_public_api(self, message: Message):
         """
         Respond with the skill's public api.
@@ -1244,6 +1280,12 @@ class OVOSSkill:
                 self.events.clear()
         except Exception as e:
             self.log.error(f"Failed to remove events for {self.skill_id}: {e}")
+
+        try:
+            self.bus.remove("open", self._handle_bus_reconnect)
+        except Exception as e:
+            self.log.error(f"Failed to remove bus reconnect listener "
+                           f"for {self.skill_id}: {e}")
 
         self.bus.emit(
             Message('detach_skill', {'skill_id': self.skill_id},

--- a/test/unittests/test_reregister_intents.py
+++ b/test/unittests/test_reregister_intents.py
@@ -1,0 +1,241 @@
+# Copyright 2026 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Re-registration of intents/vocab after the matchers lose compiled state.
+
+The intent matchers (pipeline plugins) hold skill registrations in memory,
+built from ``register_vocab`` / ``register_intent`` / ``padatious:*``
+broadcasts. Those broadcasts are load-time announcements (OVOS-INTENT-4 §10):
+a matcher (re)constructed after the skill loaded has missed them and matches
+nothing until the skill re-emits. Re-registration is implicit replacement
+(OVOS-INTENT-4 §8.1), so replaying is always safe.
+
+Skills must therefore re-drive their registrations when:
+- the intent service announces its pipeline plugins were (re)loaded
+  (``intent.service.pipelines.loaded``), e.g. after the intent service
+  process restarted while the skill process kept running;
+- the websocket to the messagebus is re-established after a drop
+  (the bus client's ``open`` event), so a messagebus restart can never
+  leave matchers without the skill's registrations.
+"""
+import os
+import tempfile
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from ovos_workshop.intents import IntentBuilder, IntentServiceInterface
+from ovos_workshop.skills.fallback import FallbackSkill
+from ovos_workshop.skills.ovos import OVOSSkill
+
+
+REGISTRATION_TOPICS = ("register_vocab", "register_intent",
+                       "padatious:register_intent",
+                       "padatious:register_entity")
+
+
+class BusCapture:
+    """Record registration traffic emitted on a FakeBus."""
+
+    def __init__(self, bus, topics=REGISTRATION_TOPICS):
+        self.messages = []
+        bus.on("message", self._capture)
+        self._topics = topics
+
+    def _capture(self, serialized):
+        message = Message.deserialize(serialized)
+        if message.msg_type in self._topics:
+            self.messages.append(message)
+
+    def clear(self):
+        self.messages.clear()
+
+    def types(self):
+        return [m.msg_type for m in self.messages]
+
+
+def _make_intent_file(content="hello world"):
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".intent", delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+
+class TestReregisterAll(unittest.TestCase):
+    """IntentServiceInterface.reregister_all replays recorded registrations."""
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.capture = BusCapture(self.bus)
+        self.interface = IntentServiceInterface(self.bus)
+        self.interface.set_id("test-skill.test")
+        self.intent_file = _make_intent_file()
+        self.entity_file = _make_intent_file("thing")
+
+    def tearDown(self):
+        for f in (self.intent_file, self.entity_file):
+            if os.path.exists(f):
+                os.remove(f)
+
+    def _register_everything(self):
+        self.interface.register_adapt_keyword(
+            "test_skillHelloKeyword", "hello", ["hi", "hey"], lang="en-US")
+        self.interface.register_adapt_regex(
+            "(?P<TestThing>.*)", lang="en-US")
+        adapt_intent = IntentBuilder("test-skill.test:hello.intent").require(
+            "test_skillHelloKeyword").build()
+        self.interface.register_adapt_intent(
+            "hello.intent", adapt_intent)
+        self.interface.register_padatious_intent(
+            "test-skill.test:file.intent", self.intent_file, "en-US")
+        self.interface.register_padatious_entity(
+            "test-skill.test:thing.entity", self.entity_file, "en-US")
+
+    def test_reregister_all_replays_everything(self):
+        self._register_everything()
+        original = sorted((m.msg_type, str(sorted(m.data.items())))
+                          for m in self.capture.messages)
+        self.capture.clear()
+
+        self.interface.reregister_all()
+
+        replayed = sorted((m.msg_type, str(sorted(m.data.items())))
+                          for m in self.capture.messages
+                          if m.msg_type != "detach_intent")
+        self.assertEqual(original, replayed)
+
+    def test_reregister_detaches_adapt_intent_before_replay(self):
+        # legacy adapt consumers append parsers instead of replacing, so the
+        # replay must be preceded by a detach of the same intent
+        self._register_everything()
+        capture = BusCapture(self.bus, topics=("detach_intent",
+                                               "register_intent"))
+        self.interface.reregister_all()
+        types = [m.msg_type for m in capture.messages]
+        self.assertIn("detach_intent", types)
+        self.assertLess(types.index("detach_intent"),
+                        types.index("register_intent"))
+        detach = [m for m in capture.messages
+                  if m.msg_type == "detach_intent"][0]
+        register = [m for m in capture.messages
+                    if m.msg_type == "register_intent"][0]
+        self.assertEqual(detach.data["intent_name"], register.data["name"])
+
+    def test_reregister_skips_detached_intents(self):
+        self._register_everything()
+        self.interface.remove_intent("hello.intent")
+        self.capture.clear()
+
+        self.interface.reregister_all()
+
+        registered_names = [m.data.get("name") for m in self.capture.messages
+                            if m.msg_type == "register_intent"]
+        self.assertNotIn("test-skill.test:hello.intent", registered_names)
+        # padatious intent is still in effect and must be replayed
+        self.assertIn("padatious:register_intent", self.capture.types())
+
+    def test_carries_skill_id_context(self):
+        self._register_everything()
+        self.capture.clear()
+        self.interface.reregister_all()
+        for message in self.capture.messages:
+            self.assertEqual(message.context.get("skill_id"),
+                             "test-skill.test")
+
+
+class ReconnectTestSkill(OVOSSkill):
+    def initialize(self):
+        self.register_vocabulary("hello", "HelloKeyword", lang="en-US")
+        self.register_intent(
+            IntentBuilder("HelloIntent").require("HelloKeyword"),
+            self.handle_hello)
+
+    def handle_hello(self, message):
+        pass
+
+
+class TestSkillReregisterTriggers(unittest.TestCase):
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.capture = BusCapture(self.bus)
+        self.skill = ReconnectTestSkill(
+            bus=self.bus, skill_id="reconnect-test.test")
+
+    def tearDown(self):
+        self.skill.default_shutdown()
+
+    def test_registers_on_load(self):
+        self.assertIn("register_vocab", self.capture.types())
+        self.assertIn("register_intent", self.capture.types())
+
+    def test_reregisters_on_bus_reconnect(self):
+        self.capture.clear()
+        # the bus client re-emits its "open" event on every reconnect
+        self.bus.ee.emit("open")
+        self.assertIn("register_vocab", self.capture.types())
+        self.assertIn("register_intent", self.capture.types())
+
+    def test_reregisters_when_pipelines_reload(self):
+        self.capture.clear()
+        self.bus.emit(Message("intent.service.pipelines.loaded"))
+        self.assertIn("register_vocab", self.capture.types())
+        self.assertIn("register_intent", self.capture.types())
+
+    def test_replayed_registrations_match_originals(self):
+        original = sorted((m.msg_type, str(sorted(m.data.items())))
+                          for m in self.capture.messages)
+        self.capture.clear()
+        self.bus.ee.emit("open")
+        replayed = sorted((m.msg_type, str(sorted(m.data.items())))
+                          for m in self.capture.messages
+                          if m.msg_type != "detach_intent")
+        self.assertEqual(original, replayed)
+
+
+class ReconnectFallbackSkill(FallbackSkill):
+    def initialize(self):
+        self.register_fallback(self.handle_fallback, 80)
+
+    def handle_fallback(self, message):
+        return False
+
+
+class TestFallbackReregister(unittest.TestCase):
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.messages = []
+        self.bus.on("message", self._capture)
+        self.skill = ReconnectFallbackSkill(
+            bus=self.bus, skill_id="reconnect-fallback.test")
+
+    def _capture(self, serialized):
+        message = Message.deserialize(serialized)
+        if message.msg_type == "ovos.skills.fallback.register":
+            self.messages.append(message)
+
+    def tearDown(self):
+        self.skill.default_shutdown()
+
+    def test_reregisters_fallback_on_reconnect(self):
+        self.assertEqual(len(self.messages), 1)
+        self.bus.ee.emit("open")
+        self.assertEqual(len(self.messages), 2)
+        self.assertEqual(self.messages[-1].data["skill_id"],
+                         "reconnect-fallback.test")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the resilience gap where intent matching is permanently lost once the pipeline matchers drop their compiled state while skills keep running.

## The problem

Registration broadcasts (`register_vocab`, `register_intent`, `padatious:*`, fallback registration) are load-time announcements (OVOS-INTENT-4 §10) — the bus has no catch-up channel. A matcher (re)constructed after a skill loaded has missed them and matches nothing: every utterance ends in `ovos.intent.unmatched` until the skill process is restarted. This happens when the intent service reloads its pipeline plugins (`intent.service.pipelines.reload` rebuilds every plugin with empty engines) or restarts in a separate process, and can follow a messagebus restart.

## The fix

- `IntentServiceInterface` records vocabulary/entity registration payloads alongside the already-recorded intents and exposes `reregister_all()`, which replays every registration currently in effect. Re-registration is implicit replacement (OVOS-INTENT-4 §8.1) so the replay is always safe; adapt intents are detached first because legacy consumers append parsers instead of replacing. Detached intents stay detached.
- `OVOSSkill` replays on two triggers:
  - `intent.service.pipelines.loaded` — the orchestrator's announcement that pipeline plugins were (re)loaded (emitted by the companion ovos-core change);
  - the bus client's `open` event after a websocket drop, so a messagebus restart can never leave matchers without this skill's registrations.
- `FallbackSkill` additionally re-emits its fallback registration, which lives in the fallback matcher's memory just like intents do.

## Tests

`test/unittests/test_reregister_intents.py`: replay fidelity (replayed payloads identical to originals), detach-before-replay for adapt intents, detached intents skipped, skill_id context propagation, both skill-level triggers, and fallback re-registration.

Companion PR: ovos-core emits `intent.service.pipelines.loaded` after (re)loading pipeline plugins and adds a real-messagebus end2end regression test that restarts the messagebus process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)