### PR TITLE
fix: default_shutdown() docstring incorrectly claims it calls skill.shutdown()

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1207,8 +1207,11 @@ class OVOSSkill:
         2) Store skill settings and remove file watchers
         3) Shutdown skill GUI to clear any active pages
         4) Shutdown the event_scheduler and remove any pending events
-        5) Call skill.shutdown() to allow skill to do any other shutdown tasks
-        6) Emit `detach_skill` Message to notify skill is shut down
+        5) Emit `detach_skill` Message to notify skill is shut down
+
+        NOTE: this method does NOT call `skill.shutdown()`. The skill-specific
+        `shutdown()` hook is invoked separately by the caller (eg.
+        `SkillManager.unload_skill()` or `__del__`), before/around this method.
         """
         if hasattr(self, 'status'):
             self.status.set_stopping()


### PR DESCRIPTION
## What was broken

`OVOSSkill.default_shutdown()` in `ovos_workshop/skills/ovos.py` has a docstring
listing 6 steps, including:

> 5) Call skill.shutdown() to allow skill to do any other shutdown tasks

However the method body never calls `self.shutdown()`. The skill-specific
`shutdown()` hook is invoked separately by the caller — e.g.
`SkillManager.unload_skill()` and `OVOSSkill.__del__()` — around
`default_shutdown()`, not from within it.

## How it fails

Anyone reading the docstring (or relying on it to reason about lifecycle
ordering / side effects) would incorrectly believe `shutdown()` runs as part
of `default_shutdown()`. This is a documentation-only defect; no runtime
behavior is affected.

## The fix

Updated the docstring to remove the false claim and added a note clarifying
that `shutdown()` is invoked separately by the caller. No code/runtime
behavior was changed.

## Verification

Ran the existing shutdown-related unit test suites (unchanged, all green):

```
test/unittests/skills/test_base.py
test/unittests/test_skill_launcher.py
test/unittests/test_skill_loader.py
test/unittests/skills/test_fallback_skill.py
test/unittests/test_abstract_app.py
```

Result: `111 passed`.

---
This is a docs-only change; no new test was added since behavior is
unchanged. Authored with AI assistance (Claude).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the shutdown sequence and responsibilities in the skill lifecycle documentation.
  * Documented that the default shutdown process sends a detach message and does not directly invoke the skill-specific shutdown hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->