### PR TITLE
fix: play_audio docstring wait timeout says 15s, actual default is 30s

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1695,7 +1695,7 @@ class OVOSSkill:
         @param filename: File to play
         @param instant: if True audio will be played instantly instead of queued with TTS
         @param wait: set to True to block while the audio
-                                 is being played for 15 seconds. Alternatively, set
+                                 is being played for 30 seconds. Alternatively, set
                                  to an integer to specify a timeout in seconds.
         """
         message = dig_for_message() or Message("")


### PR DESCRIPTION
## What was broken

`OVOSSkill.play_audio`'s docstring for the `wait` parameter said blocking would wait "15 seconds" by default:

```python
@param wait: set to True to block while the audio
             is being played for 15 seconds. Alternatively, set
             to an integer to specify a timeout in seconds.
```

But the actual code uses a 30-second default:

```python
if wait:
    timeout = 30 if isinstance(wait, bool) else wait
```

So a developer reading the docstring and calling `play_audio(path, wait=True)` would expect a 15s block, while the real behavior blocks for 30s.

## How it fails

Purely a documentation/discoverability issue — no crash or exception. Anyone relying on the docstring's stated timeout to reason about skill responsiveness or write timing-sensitive code would be misled.

## The fix

Updated the docstring to say 30 seconds, matching the actual default. No runtime behavior was changed.

Checked sibling audio-related methods (`speak`, `speak_dialog`) for the same copy-paste mismatch — their docstrings say 15 seconds and their code (`timeout = 15 if isinstance(wait, bool) else wait`) actually defaults to 15 seconds, so those are correct and were left untouched.

## Verification

Ran the nearest test module (docs-only change, so just confirming nothing broke):

```
pytest test/unittests/skills/test_ovos.py
14 passed
```

---
Note: this is unrelated to draft PR #476 (also a docstring-only fix, for `default_shutdown`).

This PR was authored with AI assistance (Claude).