### PR TITLE
chore: import EnclosureAPI from ovos-gui-api-client

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -29,7 +29,7 @@ from typing import Dict, Callable, List, Optional, Union
 
 from json_database import JsonStorage
 from ovos_bus_client import MessageBusClient
-from ovos_bus_client.apis.enclosure import EnclosureAPI
+from ovos_gui_api_client import EnclosureAPI
 from ovos_bus_client.apis.events import EventSchedulerInterface
 from ovos_bus_client.apis.gui import GUIInterface
 from ovos_bus_client.apis.ocp import OCPInterface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.9"
 dependencies = [
     "ovos-utils>= 0.13.3a2,<1.0.0",  # FakeBus folds before handlers (ovos-utils#396) — keeps in-place add_context mutations alive so intent-layer gating works
     "ovos_bus_client>=2.6.2a2,<3.0.0",  # HandlerLifecycle done-signal util (#246) + singleton-registry SessionManager (2.6.2a2)
+    "ovos-gui-api-client>=0.1.0,<1.0.0",  # EnclosureAPI moved here; bus-client copy is a deprecation shim removed in bus-client 3.0.0
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-spec-tools>=1.2.3a1",  # canonical SessionManager registry + OVOS-INTENT-4 intent-definition primitives
     "ovos-yes-no-plugin>=0.3.0,<1.0.0",

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -44,7 +44,7 @@ class TestOVOSSkill(unittest.TestCase):
         from ovos_utils.events import EventContainer
         from ovos_workshop.intents import IntentServiceInterface
         from ovos_utils.process_utils import RuntimeRequirements
-        from ovos_bus_client.apis.enclosure import EnclosureAPI
+        from ovos_gui_api_client import EnclosureAPI
         from ovos_workshop.filesystem import FileSystemAccess
         from ovos_workshop.resource_files import SkillResources
 


### PR DESCRIPTION
## Summary
Consumer catch-up step of the enclosure -> GUI migration: `EnclosureAPI` now lives in `ovos-gui-api-client`. The `ovos_bus_client.apis.enclosure` copy is a deprecation shim that will be removed in `ovos-bus-client` 3.0.0.

- switch `ovos_workshop/skills/ovos.py` import to `from ovos_gui_api_client import EnclosureAPI`
- add `ovos-gui-api-client>=0.1.0,<1.0.0` to `pyproject.toml` dependencies (0.1.0 is the first release exporting `EnclosureAPI`)
- update the matching isinstance check in `test/unittests/skills/test_base.py`

`EventSchedulerInterface` was checked too — dev already imports it from `ovos_bus_client.apis.events`, the current (non-deprecated) path, so no change was needed there.

Authored with Claude Code.

## Test plan
- [x] Fresh venv smoke: `python -W always -c "from ovos_workshop.skills.ovos import OVOSSkill"` — no EnclosureAPI deprecation warning
- [x] Full suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test` — 514 passed, 1 pre-existing unrelated failure (`test_inline_vocab_refs.py::test_padacioso_raw_reference_is_rejected`, confirmed failing on `origin/dev` baseline too, untouched by this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated skill enclosure controls to use the current GUI API implementation.
  * Improved compatibility for applications relying on the skill’s enclosure interface.

* **Chores**
  * Added the required GUI API client package for runtime operation.
  * Updated automated checks to validate the revised enclosure integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->