### PR TITLE
fix: compare ovos_core.version tuple in _core_owns_utterance_handled (no packaging dep)

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -69,27 +69,14 @@ from ovos_workshop.skills.util import join_word_list, simple_trace
 
 
 def _core_owns_utterance_handled() -> bool:
-    """PIPELINE-1 §9.5: ``ovos.utterance.handled`` is the orchestrator's universal
-    end-marker — ovos-core owns it on EVERY terminal path, the matched path included.
-
-    ovos-core began emitting it on the matched path in **2.3.0** (the §9.5 change
-    landed on the 2.2.x line, so by semver the first release carrying it is the next
-    minor, 2.3.0a1). When the installed core is that version or newer this returns
-    ``True`` and the skill framework must NOT also emit it, or consumers would see
-    the end-marker twice.
-
-    During the migration window an older core (or none, e.g. a workshop-only test
-    env) does not emit it on the matched path, so the framework still must. This
-    returns ``False`` then — including when core is absent/unknown — so the framework
-    keeps emitting (back-compat). Double emits are tolerated by spec consumers, so
-    erring toward the framework emitting is the safe default.
-    """
+    """PIPELINE-1 §9.5: core >= 2.3.0 emits ``ovos.utterance.handled`` on every
+    terminal path, the matched path included — the framework must not double-emit.
+    Older or absent core -> the framework still owns the emit (back-compat)."""
     try:
-        from importlib.metadata import version
-        from packaging.version import parse
-        return parse(version("ovos-core")) >= parse("2.3.0a1")
-    except Exception:
-        return False  # core absent/unknown -> framework keeps emitting (back-compat)
+        from ovos_core.version import OVOS_VERSION_TUPLE
+    except ImportError:
+        return False
+    return OVOS_VERSION_TUPLE >= (2, 3, 0)
 
 
 class OVOSSkill:

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -394,6 +394,42 @@ class TestOVOSSkill(unittest.TestCase):
         self.assertIn("mycroft.skill.handler.complete", types)
         self.assertIn(SpecMessage.UTTERANCE_HANDLED.value, types)
 
+    def _patched_core_version(self, tup):
+        import sys, types
+        pkg = types.ModuleType("ovos_core")
+        mod = types.ModuleType("ovos_core.version")
+        mod.OVOS_VERSION_TUPLE = tup
+        pkg.version = mod
+        from unittest.mock import patch
+        return patch.dict(sys.modules, {"ovos_core": pkg, "ovos_core.version": mod})
+
+    def test_core_owns_utterance_handled_true_above_threshold(self):
+        from ovos_workshop.skills.ovos import _core_owns_utterance_handled
+        with self._patched_core_version((2, 5, 6)):
+            self.assertTrue(_core_owns_utterance_handled())
+        with self._patched_core_version((2, 3, 0)):
+            self.assertTrue(_core_owns_utterance_handled())
+
+    def test_core_owns_utterance_handled_false_below_threshold(self):
+        from ovos_workshop.skills.ovos import _core_owns_utterance_handled
+        with self._patched_core_version((2, 2, 9)):
+            self.assertFalse(_core_owns_utterance_handled())
+
+    def test_core_owns_utterance_handled_false_when_core_absent(self):
+        import builtins
+        from unittest.mock import patch
+        from ovos_workshop.skills.ovos import _core_owns_utterance_handled
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("ovos_core"):
+                raise ImportError("simulated absent ovos-core")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            self.assertFalse(_core_owns_utterance_handled())
+
     def test_on_event_error(self):
         from ovos_bus_client.message import Message
         msg = Message("trigger", {}, {"session": {"session_id": "sess1"}})


### PR DESCRIPTION
The PIPELINE-1 §9.5 gate parsed pip metadata via `packaging`, an **undeclared** dependency — when absent, the `except` swallowed the ImportError, the gate returned False, and skills double-emitted `ovos.utterance.handled` (found live-testing #431).

Fix: drop `packaging` and `importlib.metadata` entirely. ovos-core exports `OVOS_VERSION_TUPLE` for exactly this — import it and compare against `(2, 3, 0)`. ImportError ⇒ core absent ⇒ framework keeps owning the emit (back-compat).

Tests cover: above/at threshold ⇒ True, below ⇒ False, core absent ⇒ False.

Model: Claude Fable 5 via Claude Code