### PR TITLE
fix: keep .voc filename case in load_skill_vocabulary

### DIFF
--- a/ovos_workshop/resource_files.py
+++ b/ovos_workshop/resource_files.py
@@ -932,7 +932,9 @@ class SkillResources:
                 file_name for file_name in files if file_name.endswith(".voc")
             )
             for file_name in vocabulary_files:
-                vocab_type = alphanumeric_skill_id + file_name[:-4].title()
+                # keep exact filename case: str.title() lowercases
+                # "HelloWorldKeyword" -> "Helloworldkeyword", breaking vocab lookups
+                vocab_type = alphanumeric_skill_id + file_name[:-4]
                 vocabulary = self.load_vocabulary_file(file_name)
                 if vocabulary:
                     skill_vocabulary[vocab_type] = vocabulary

--- a/test/unittests/test_resource_files_extended.py
+++ b/test/unittests/test_resource_files_extended.py
@@ -238,5 +238,28 @@ class TestResourceFileTypes(unittest.TestCase):
         self.assertIn("key", result)
 
 
+class TestLoadSkillVocabularyCasing(unittest.TestCase):
+    """load_skill_vocabulary must preserve the exact case of multi-word
+    CamelCase ``.voc`` filenames (e.g. ``HelloWorldKeyword.voc``)."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        locale_dir = Path(self.tmp, "locale", "en-us", "vocab")
+        locale_dir.mkdir(parents=True)
+        (locale_dir / "HelloWorldKeyword.voc").write_text(
+            "hello world\ngreetings\n")
+
+    def tearDown(self) -> None:
+        if self.tmp and os.path.exists(self.tmp):
+            shutil.rmtree(self.tmp)
+
+    def test_camel_case_filename_case_preserved(self) -> None:
+        from ovos_workshop.resource_files import SkillResources
+        sr = SkillResources(self.tmp, "en-us")
+        skill_vocab = sr.load_skill_vocabulary("testskill")
+        self.assertIn("testskillHelloWorldKeyword", skill_vocab)
+        self.assertNotIn("testskillHelloworldkeyword", skill_vocab)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

`SkillResources.load_skill_vocabulary()` applied `str.title()` to `.voc`
filenames when building the `vocab_type` key. For a multi-word CamelCase
filename like `HelloWorldKeyword.voc`, `str.title()` only capitalizes the
very first character of the whole run and lowercases everything else
(there are no separator characters for it to key off), turning it into
`Helloworldkeyword`.

## Why

That silently mismatches the `vocab_type` that
`IntentBuilder.require("HelloWorldKeyword")` produces (the exact string
given is used verbatim by `munge_intent_parser`). It broke real adapt
matching for any multi-word CamelCase vocab filename, and left the
OVOS-INTENT-4 keyword-sample cache unreachable.

## Fix

Keep the filename's exact case when building `vocab_type`.

## Context

Split out of #431 as an independent, single-concern fix. #431's
OVOS-INTENT-4 keyword-sample cache depends on this fix to correctly look
up multi-word CamelCase vocab filenames.

Model: Claude Fable 5 via Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the exact capitalization of multi-word vocabulary filenames when loading skill vocabulary.
  * Improved vocabulary lookups for files using CamelCase names.

* **Tests**
  * Added coverage confirming that filename capitalization is retained and incorrectly normalized variants are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->