### PR TITLE
fix: gate ovos.utterance.handled in converse/fallback when core owns the emit (PIPELINE-1 §9.5)

### DIFF
--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -14,7 +14,7 @@ from padacioso import IntentContainer
 
 from ovos_workshop.decorators.killable import AbortEvent, killable_event, AbortQuestion
 from ovos_workshop.resource_files import ResourceFile
-from ovos_workshop.skills.ovos import OVOSSkill
+from ovos_workshop.skills.ovos import _core_owns_utterance_handled, OVOSSkill
 
 
 class ConversationalSkill(OVOSSkill):
@@ -200,10 +200,12 @@ class ConversationalSkill(OVOSSkill):
                 response_message.data["error"] =  repr(e)
 
         self.bus.emit(response_message)
-        if is_latest:
-            self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
-        else:
-            self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
+        if not _core_owns_utterance_handled():
+            # PIPELINE-1 §9.5: skip if core (>=2.3.0a1) already owns this emit.
+            if is_latest:
+                self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
+            else:
+                self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
 
     def _handle_converse_intents(self, message):
         """ called before converse method

--- a/ovos_workshop/skills/fallback.py
+++ b/ovos_workshop/skills/fallback.py
@@ -23,7 +23,7 @@ from ovos_utils.log import LOG
 from ovos_utils.skills import get_non_properties
 
 from ovos_workshop.decorators.killable import AbortEvent, killable_event
-from ovos_workshop.skills.ovos import OVOSSkill
+from ovos_workshop.skills.ovos import _core_owns_utterance_handled, OVOSSkill
 
 
 class FallbackSkill(OVOSSkill):
@@ -158,7 +158,9 @@ class FallbackSkill(OVOSSkill):
         self.bus.emit(message.forward(
             f"ovos.skills.fallback.{self.skill_id}.response",
             data={"result": status, "fallback_handler": handler_name}))
-        self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
+        if not _core_owns_utterance_handled():
+            # PIPELINE-1 §9.5: skip if core (>=2.3.0a1) already owns this emit.
+            self.bus.emit(message.forward(SpecMessage.UTTERANCE_HANDLED))
 
     def register_fallback(self, handler: Callable, priority: int) -> None:
         """


### PR DESCRIPTION
## What

`ConversationalSkill._collect_converse_skills` (converse.py) and
`FallbackSkill._on_handle_fallback_ack`-adjacent handling (fallback.py)
unconditionally emitted `ovos.utterance.handled` on the matched-converse
and matched-fallback terminal paths.

## Why

Per PIPELINE-1 §9.5, ovos-core (>=2.3.0a1) is the sole owner of the
universal `ovos.utterance.handled` end-marker on every terminal path,
including converse and fallback. Emitting it unconditionally here
double-emits the end-marker once core also owns it. The plain
intent-handler path in `OVOSSkill` already guards this emit behind
`_core_owns_utterance_handled()`; converse and fallback did not.

## Fix

Gate both emits behind the existing `_core_owns_utterance_handled()`
helper, matching the intent-handler behavior: emit only when core is
absent/older than 2.3.0a1 (migration window), skip when core already owns
it.

## Context

Split out of #431 as an independent, single-concern fix — no dependency
on the other pieces of #431. Related to #482 (gate hardening elsewhere in
the codebase); this PR is independent of it.

Model: Claude Fable 5 via Claude Code
