### PR TITLE
test: e2e regression guard for INTENT-4 keyword samples with CamelCase vocab

### DIFF
--- a/test/end2end/keyword_casing_test_skill/__init__.py
+++ b/test/end2end/keyword_casing_test_skill/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2026 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fixture skill for the vocab-casing regression test (PR #485).
+
+Loads a CamelCase-named ``.voc`` file (``HelloWorldKeyword.voc``) purely via
+the normal skill-loading path (``load_data_files`` -> ``load_skill_vocabulary``),
+never via ``self.register_vocabulary``, so the on-disk basename casing is what
+determines the vocab_type used by the INTENT-4 keyword-sample cache.
+"""
+from ovos_workshop.intents import IntentBuilder
+from ovos_workshop.skills.ovos import OVOSSkill
+
+
+class KeywordCasingTestSkill(OVOSSkill):
+    """Registers one adapt intent that requires a keyword loaded from a
+    CamelCase ``.voc`` file, to guard against the .title() casing bug."""
+
+    def initialize(self):
+        # NOTE: no self.register_vocabulary() call here on purpose - the
+        # keyword samples must come exclusively from the .voc file on disk
+        # via the automatic load_data_files() -> load_skill_vocabulary() path.
+        adapt_intent = (IntentBuilder("greet")
+                        .require("HelloWorldKeyword")
+                        .build())
+        self.register_intent(adapt_intent, self.handle_greet)
+
+    def handle_greet(self, message):
+        pass
+
+
+def create_skill():
+    return KeywordCasingTestSkill()

--- a/test/end2end/keyword_casing_test_skill/locale/en-us/HelloWorldKeyword.voc
+++ b/test/end2end/keyword_casing_test_skill/locale/en-us/HelloWorldKeyword.voc
@@ -1,0 +1,3 @@
+hello world
+hi there
+greetings

--- a/test/end2end/test_keyword_casing_e2e.py
+++ b/test/end2end/test_keyword_casing_e2e.py
@@ -1,0 +1,110 @@
+# Copyright 2026 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Real-bus end-to-end regression guard for the vocab-casing bug fixed by
+PR #485.
+
+``load_skill_vocabulary`` used to run ``.title()`` on ``.voc`` basenames, so a
+CamelCase file like ``HelloWorldKeyword.voc`` became the vocab_type
+``Helloworldkeyword`` on the wire, breaking the INTENT-4 exact-string keyword
+sample cache (``_adapt_keyword_samples``) and causing
+``ovos.intent.register.keyword`` to be emitted with an empty ``samples`` list
+for that keyword. Adapt utterance matching itself is case-insensitive, so the
+casing bug is invisible there - the *only* observable discriminator is this
+spec keyword-emit carrying non-empty samples.
+
+Boots a real (mini) OVOS stack via ovoscope's ``MiniCroft``, loads the
+``keyword_casing_test_skill`` fixture (a CamelCase ``.voc`` file loaded purely
+through the normal skill-loading path, never via ``register_vocabulary``), and
+asserts the ``ovos.intent.register.keyword`` message carries the expected
+non-empty samples for that keyword.
+"""
+import sys
+from os.path import dirname
+
+import pytest
+
+from ovoscope import get_minicroft
+
+from ovos_spec_tools import SpecMessage
+
+# the fixture skill lives next to this file in its own package directory so its
+# `root_dir` resolves there and its locale/en-us resources are discoverable.
+sys.path.insert(0, dirname(__file__))
+
+SKILL_ID = "keyword.casing.e2e.test"
+
+EXPECTED_SAMPLES = ["hello world", "hi there", "greetings"]
+
+
+def _boot():
+    """Boot a real MiniCroft with the keyword-casing fixture skill."""
+    from keyword_casing_test_skill import KeywordCasingTestSkill
+    return get_minicroft([SKILL_ID],
+                         extra_skills={SKILL_ID: KeywordCasingTestSkill},
+                         modernize=False, emit_legacy=False)
+
+
+def _of_type(mc, msg_type):
+    """All boot messages of a given type (data, context) tuples."""
+    return [(m.data, m.context) for m in mc.boot_messages
+            if m.msg_type == str(msg_type)]
+
+
+class TestKeywordCasingE2E:
+    """The fixture skill is loaded once; assertions inspect the registration
+    topics captured during boot."""
+
+    mc = None
+
+    @classmethod
+    def setup_class(cls):
+        from ovos_utils.log import LOG
+        LOG.set_level("ERROR")
+        cls.mc = _boot()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.mc.stop()
+
+    def test_keyword_topic_flows_on_real_bus(self):
+        """Exactly one ``ovos.intent.register.keyword`` for the CamelCase
+        keyword's adapt intent."""
+        kw = _of_type(self.mc, SpecMessage.INTENT_REGISTER_KEYWORD)
+        assert len(kw) == 1, "spec keyword topic did not flow on the real bus"
+
+    def test_camelcase_keyword_has_nonempty_samples(self):
+        """Regression guard for PR #485: the CamelCase-named keyword must
+        carry its real, non-empty samples from the .voc file - not an empty
+        list caused by a mismatched, `.title()`-mangled vocab_type."""
+        data, context = _of_type(self.mc, SpecMessage.INTENT_REGISTER_KEYWORD)[0]
+
+        assert data["skill_id"] == SKILL_ID
+        assert data["intent_name"] == "greet"
+        assert context["skill_id"] == SKILL_ID
+
+        assert "required" in data
+        req = {d["name"]: d["samples"] for d in data["required"]}
+
+        # the exact CamelCase name must be present - not "Helloworldkeyword"
+        assert "HelloWorldKeyword" in req, (
+            f"expected CamelCase keyword name preserved on the wire, got: "
+            f"{list(req.keys())}"
+        )
+        samples = req["HelloWorldKeyword"]
+        assert samples, "keyword samples must not be empty"
+        assert samples == EXPECTED_SAMPLES
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds a real-bus ovoscope end2end test guarding against the vocab-casing bug fixed by #485
- `load_skill_vocabulary` used to run `.title()` on `.voc` basenames, turning a CamelCase file like `HelloWorldKeyword.voc` into the vocab_type `Helloworldkeyword` on the wire, which broke the INTENT-4 exact-string keyword-sample cache (`_adapt_keyword_samples`) and caused `ovos.intent.register.keyword` to be emitted with empty `samples`
- Adapt utterance matching itself is case-insensitive, so this casing bug is invisible there — the only observable discriminator is the INTENT-4 keyword spec-emit carrying non-empty samples, which is what this test asserts
- New fixture skill (`test/end2end/keyword_casing_test_skill`) loads a CamelCase-named `.voc` file purely through the normal skill-loading path (`load_data_files` -> `load_skill_vocabulary`), never via `register_vocabulary`, so on-disk basename casing is what drives the assertion
- Related: #431

## Test plan
- [x] `pytest test/end2end/test_keyword_casing_e2e.py -v` passes (2 passed) in a fresh venv
- [x] Full `test/end2end/` suite passes together (10 passed), confirming no interference with the existing INTENT-4 producer e2e test
- [x] Sabotage check: locally re-applied the old `.title()` bug in `ovos_workshop/resource_files.py` -> new test fails (0 keyword messages emitted); reverted -> passes again

🤖 Generated with [Claude Code](https://claude.com/claude-code)