### PR TITLE
fix: bump padacioso floor to 2.2.1a1 so dangling <name> refs raise MalformedTemplate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "ovos-plugin-manager>=2.4.0a1,<3.0.0",
     "rapidfuzz",
     "langcodes",
-    "padacioso>=1.0.0,<3.0.0",
+    "padacioso>=2.2.1a1,<3.0.0",  # OVOS-INTENT-1 §3.7: add_intent delegates expansion to ovos_spec_tools.expand, which raises MalformedTemplate on a dangling <name> reference instead of silently training the literal token
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Root cause

`test/unittests/test_inline_vocab_refs.py::test_padacioso_raw_reference_is_rejected` expects padacioso's own `IntentContainer.add_intent()` to raise `ovos_spec_tools.expansion.MalformedTemplate` when handed a sample containing an unresolved `<name>` reference, per **OVOS-INTENT-1 §3.7**: an inline `<name>` in a `.intent` file is an authoring convenience that must be resolved from the sibling `.voc` before it ever reaches an intent engine — a dangling reference must never be trained as a literal token.

`pyproject.toml` pinned `padacioso>=1.0.0,<3.0.0` (`pyproject.toml:25`). That floor resolves to the PyPI-published `1.0.0` release, whose `add_intent()` (see `padacioso/__init__.py` in that release) calls its own local `expand_parentheses()`/`normalize_example()` and has no dependency on `ovos_spec_tools` at all:

```python
expanded = []
for l in lines:
    expanded += expand_parentheses(normalize_example(l))
```

Fed `"what about <thing>"`, `1.0.0` happily trains on the literal `<thing>` token instead of rejecting it — confirmed locally:

```python
>>> from padacioso import IntentContainer
>>> e = IntentContainer()
>>> e.add_intent('foo', ['what about <thing>'])
>>> e.calc_intent('what about <thing>')
{'entities': {}, 'conf': 1, 'name': 'foo'}
```

The fix for this already landed upstream in the padacioso repo (`OpenVoiceOS/padacioso#70`, *"fix: skip malformed template samples instead of crashing registration"*), which switched `add_intent()` to delegate expansion to `ovos_spec_tools.expand()` — the exact function that raises `MalformedTemplate` for a dangling `<name>`:

```python
for line in lines:
    for e in expand(line):   # ovos_spec_tools.expand
        expanded.append(_normalize(e))
```

That change shipped to PyPI as prerelease **`padacioso==2.2.1a1`**, but ovos-workshop's dependency floor never picked it up because `>=1.0.0` is satisfied by the older stable release.

## Why this isn't an ovos-workshop bug

`register_padatious_intent()` in `ovos_workshop/intents.py` already does the right thing today — the two registration-path tests prove it and both passed before this fix:
- `test_inline_reference_resolved_before_engine` — inline `<name>` correctly resolved to `(a|b|c)` when `vocabs=` is supplied.
- `test_raw_reference_without_vocabs_is_unresolved` — raw `<name>` correctly left unresolved on the wire when no vocab map is available (there is nothing to resolve it against at that point).

The rejection this test checks for is deliberately deferred to the engine itself — it's the last line of defense against a dangling reference that slipped through registration unresolved. That defense only exists in padacioso `>=2.2.1a1`.

## Fix

Bump the floor: `padacioso>=1.0.0,<3.0.0` → `padacioso>=2.2.1a1,<3.0.0`, with an inline comment, following this repo's established prerelease-floor-pin convention already used two lines above for `ovos-spec-tools>=1.5.1a1`.

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/unittests/test_inline_vocab_refs.py -v` — 9/9 pass (was 8 passed / 1 failed on bare `dev`)
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/unittests/ -v` — 547 passed, 0 failed, 0 skipped. `TestKillableIntents::test_get_response` did not flake in this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Padacioso dependency to a newer compatible release.
  * Clarified template expansion behavior for dangling references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->