### PR TITLE
test: restore SessionManager.bus after end2end MiniCroft teardown

### DIFF
--- a/test/end2end/test_intent4_producer_e2e.py
+++ b/test/end2end/test_intent4_producer_e2e.py
@@ -26,6 +26,7 @@ import pytest
 
 from ovoscope import get_minicroft
 
+from ovos_bus_client.session import SessionManager
 from ovos_spec_tools import SpecMessage
 
 # the fixture skill lives next to this file in its own package directory so its
@@ -61,11 +62,18 @@ class TestIntent4ProducerE2E:
     def setup_class(cls):
         from ovos_utils.log import LOG
         LOG.set_level("ERROR")
+        # booting a real MiniCroft runs a real IntentService, whose
+        # startup calls SessionManager.connect_to_bus(mc.bus) - this
+        # mutates the process-wide SessionManager.bus class attribute.
+        # Save/restore it so later tests don't inherit a bus pointing at
+        # this (now-stopped) MiniCroft instance.
+        cls._saved_bus = SessionManager.bus
         cls.mc = _boot()
 
     @classmethod
     def teardown_class(cls):
         cls.mc.stop()
+        SessionManager.bus = cls._saved_bus
 
     # ------------------------------------------------------------------ §5
 

--- a/test/end2end/test_keyword_casing_e2e.py
+++ b/test/end2end/test_keyword_casing_e2e.py
@@ -36,6 +36,7 @@ import pytest
 
 from ovoscope import get_minicroft
 
+from ovos_bus_client.session import SessionManager
 from ovos_spec_tools import SpecMessage
 
 # the fixture skill lives next to this file in its own package directory so its
@@ -71,11 +72,18 @@ class TestKeywordCasingE2E:
     def setup_class(cls):
         from ovos_utils.log import LOG
         LOG.set_level("ERROR")
+        # booting a real MiniCroft runs a real IntentService, whose
+        # startup calls SessionManager.connect_to_bus(mc.bus) - this
+        # mutates the process-wide SessionManager.bus class attribute.
+        # Save/restore it so later tests don't inherit a bus pointing at
+        # this (now-stopped) MiniCroft instance.
+        cls._saved_bus = SessionManager.bus
         cls.mc = _boot()
 
     @classmethod
     def teardown_class(cls):
         cls.mc.stop()
+        SessionManager.bus = cls._saved_bus
 
     def test_keyword_topic_flows_on_real_bus(self):
         """Exactly one ``ovos.intent.register.keyword`` for the CamelCase


### PR DESCRIPTION
## Root cause

Test-order pollution: `test/unittests/skills/test_decorators.py::TestKillableIntents::test_get_response` fails when run after `test/end2end/` in the same pytest invocation, but passes standalone.

**Polluter**: `test/end2end/test_keyword_casing_e2e.py::TestKeywordCasingE2E` and `test/end2end/test_intent4_producer_e2e.py::TestIntent4ProducerE2E` (either alone reproduces it).

**Leaked state**: `SessionManager.bus` (`ovos_bus_client.session.SessionManager`), a process-wide class attribute.

Both test classes boot a real `ovoscope.get_minicroft(...)` in `setup_class`, which starts a real `ovos_core.intent_services.IntentService`. `IntentService.__init__` calls `SessionManager.connect_to_bus(self.bus)` (`ovos_bus_client/session.py:1348-1354`), which does `cls.bus = bus` — mutating the shared singleton. `teardown_class` calls `mc.stop()` but never restores `SessionManager.bus`, so it's left pointing at the now-dead MiniCroft bus for the rest of the process. `test/unittests/test_ask_e2e.py` already has the correct pattern (`cls._saved_bus = SessionManager.bus` / restore), these two end2end files were missing it.

**How it breaks the victim test**: `test_get_response` calls `self.skill.instance.get_response(...)`, which calls `speak_dialog(..., expect_response=True, wait=True)` → `SessionManager.wait_while_speaking()` (`ovos_bus_client/session.py:1456-1490`). Its guard `if not cls.bus: return` no longer short-circuits since `cls.bus` is the stale MiniCroft bus (truthy). It registers a `recognizer_loop:audio_output_end` listener on that stale bus and blocks up to its 15s timeout — the test's own `self.bus.emit(Message("recognizer_loop:audio_output_end", ...))` goes to the test's fresh `FakeBus`, which the stale listener never sees. Because `get_response()`'s thread is stuck inside `wait_while_speaking`, it never reaches `_real_wait_response`, so the `@killable_event("mycroft.skills.abort_question", ...)` listener (`ovos_workshop/skills/ovos.py:1941`) is never registered. The test's `mycroft.skills.abort_question` message is emitted but nothing handles it, so `question aborted` is never spoken and the assertion fails.

## Fix

`test: ...` — test hygiene, not production code. Save/restore `SessionManager.bus` around MiniCroft boot in both `test_keyword_casing_e2e.py` and `test_intent4_producer_e2e.py`, matching the existing pattern already used in `test_ask_e2e.py`.

## Verification

- `test/unittests` alone: only the known unrelated failure (`test_inline_vocab_refs.py::test_padacioso_raw_reference_is_rejected`, being fixed separately).
- `test/end2end/test_keyword_casing_e2e.py` + `test_decorators.py::TestKillableIntents::test_get_response`: was 1 failed → now 3 passed.
- `test/end2end/test_intent4_producer_e2e.py` + same: was 1 failed → now 9 passed.
- `test/end2end` + same: was 1 failed → now 11 passed.
- Full suite `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/ -v`: 556 passed, 1 failed (only the known unrelated `test_padacioso_raw_reference_is_rejected`).

## Test plan
- [x] `pytest test/unittests -v` green except known unrelated failure
- [x] Minimal polluting pairs re-verified green
- [x] Full `pytest test/ -v` green except known unrelated failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test isolation by restoring shared session state after test execution.
  * Prevented test suites from inheriting state from previously stopped service instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->