### PR TITLE
fix: bind intent dispatch handlers to canonical INTENT-4 intent names

### DIFF
--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1369,6 +1369,18 @@ class OVOSSkill:
         if handler:
             self.add_event(name, handler, 'mycroft.skill.handler',
                            activation=True, is_intent=True)
+            # INTENT-4: pipelines are migrating to dispatch on the canonical,
+            # suffix-less intent name (`<skill_id>:<file>`, no `.intent`) instead
+            # of this legacy `<skill_id>:<file>.intent` topic. Both identities
+            # are emitted on the wire by register_template above, so bind the
+            # handler to both -- whichever name the matching pipeline used to
+            # dispatch, a handler is bound. Drop the legacy binding once all
+            # supported pipelines have migrated (padatious-pipeline #89,
+            # padacioso #73).
+            canonical = name[:-len('.intent')] if name.endswith('.intent') else name
+            if canonical != name:
+                self.add_event(canonical, handler, 'mycroft.skill.handler',
+                               activation=True, is_intent=True)
 
     def register_entity_file(self, entity_file: str):
         """
@@ -2371,6 +2383,13 @@ class OVOSSkill:
             self.log.info('Disabling intent ' + intent_name)
             name = f'{self.skill_id}:{intent_name}'
             self.intent_service.remove_intent(name)
+            # unbind the dispatch handler from both the legacy suffixed name
+            # and the INTENT-4 canonical suffix-less name (see
+            # register_intent_file, which binds both)
+            self.remove_event(name)
+            canonical = name[:-len('.intent')] if name.endswith('.intent') else name
+            if canonical != name:
+                self.remove_event(canonical)
 
             langs = [self.core_lang] + self.secondary_langs
             for lang in langs:

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -497,6 +497,72 @@ class TestOVOSSkill(unittest.TestCase):
             f"{skill.skill_id}:time.intent", uk_samples, "uk-UA",
             blacklisted_words=[], slot_blacklist={}, vocabs=ANY)
 
+    def test_register_intent_file_binds_canonical_and_legacy_events(self):
+        # INTENT-4: register_intent_file dual-emits the legacy suffixed name
+        # (`<skill_id>:<file>.intent`) and the canonical suffix-less name
+        # (`<skill_id>:<file>`) on the wire; the dispatch handler must be
+        # bound to BOTH, since pipelines are migrating to dispatch on the
+        # canonical name (padatious-pipeline #89, padacioso #73).
+        skill = OVOSSkill(bus=FakeBus(), skill_id=self.skill_id)
+        skill._lang_resources = dict()
+        skill.intent_service = Mock()
+        skill.res_dir = join(dirname(__file__), "test_locale")
+        skill.config_core["lang"] = "en-US"
+        skill.config_core["secondary_langs"] = []
+
+        legacy_name = f"{skill.skill_id}:time.intent"
+        canonical_name = f"{skill.skill_id}:time"
+
+        handler = Mock(__name__="test")
+        skill.register_intent_file("time.intent", handler)
+
+        self.assertTrue(any(n == legacy_name for n, _ in skill.events))
+        self.assertTrue(any(n == canonical_name for n, _ in skill.events))
+
+    def test_register_intent_file_canonical_topic_fires_handler(self):
+        # emitting the canonical (suffix-less) topic on the bus must invoke
+        # the registered handler, matching how a migrated pipeline dispatches
+        bus = FakeBus()
+        skill = OVOSSkill(bus=bus, skill_id=self.skill_id)
+        skill._lang_resources = dict()
+        skill.intent_service = Mock()
+        skill.res_dir = join(dirname(__file__), "test_locale")
+        skill.config_core["lang"] = "en-US"
+        skill.config_core["secondary_langs"] = []
+
+        called = Event()
+
+        def handler(message):
+            called.set()
+
+        handler.__name__ = "test_handler"
+        skill.register_intent_file("time.intent", handler)
+
+        canonical_name = f"{skill.skill_id}:time"
+        from ovos_bus_client.message import Message
+        bus.emit(Message(canonical_name, {}, {}))
+        self.assertTrue(called.wait(2))
+
+    def test_disable_intent_removes_both_events(self):
+        skill = OVOSSkill(bus=FakeBus(), skill_id=self.skill_id)
+        skill._lang_resources = dict()
+        skill.intent_service = Mock()
+        skill.intent_service.__contains__ = Mock(return_value=True)
+        skill.res_dir = join(dirname(__file__), "test_locale")
+        skill.config_core["lang"] = "en-US"
+        skill.config_core["secondary_langs"] = []
+
+        legacy_name = f"{skill.skill_id}:time.intent"
+        canonical_name = f"{skill.skill_id}:time"
+
+        skill.register_intent_file("time.intent", Mock(__name__="test"))
+        self.assertTrue(any(n == legacy_name for n, _ in skill.events))
+        self.assertTrue(any(n == canonical_name for n, _ in skill.events))
+
+        skill.disable_intent("time.intent")
+        self.assertFalse(any(n == legacy_name for n, _ in skill.events))
+        self.assertFalse(any(n == canonical_name for n, _ in skill.events))
+
     def test_register_entity_file(self):
         skill = OVOSSkill(bus=self.bus, skill_id=self.skill_id)
         skill._lang_resources = dict()


### PR DESCRIPTION
## Root cause

`OVOSSkill.register_intent_file()` dual-**registers** each padatious intent on
the wire -- `IntentServiceInterface.register_template()` emits both the
legacy `<skill_id>:<file>.intent` topic (`emit_legacy_register_template`) and
the INTENT-4 canonical suffix-less `<skill_id>:<file>` topic
(`SpecMessage.INTENT_REGISTER_TEMPLATE`) -- but only **binds** the dispatch
handler to the legacy name, via a single `self.add_event(name, handler, ...)`
call where `name` still carries the `.intent` suffix.

Pipeline plugins are moving to register-time alias collapse under the
canonical name (OpenVoiceOS/ovos-padatious-pipeline-plugin#89,
OpenVoiceOS/padacioso#73), so `IntentService._dispatch_match` in core now
dispatches on the canonical topic. With no handler bound to that topic, skill
handlers never fire -- the utterance matches, but nothing runs.

Repro (pre-fix): with #89's worktree plugin installed in
`~/.venvs/core-alpha-bump`, `pytest test/end2end/test_padatious.py -v` from
ovos-core's `bump-latest-alphas` worktree failed `test_padatious_match` with
a handler timeout, while the two blacklist tests (which don't depend on
handler dispatch) passed.

## Fix

`register_intent_file()` now binds the handler to **both** names -- the
legacy suffixed name and the canonical suffix-less name -- so dispatch works
regardless of which identity the matching pipeline used. Both bindings are
kept for the migration window; older pipelines still dispatch on the legacy
name. The `_register_adapt_intent` (adapt) path was checked for the same gap
and does not have it: `intent_parser.name` (used both for the wire
registration and for `add_event`) is a single identity with no legacy/
canonical split, since only padatious names ever carried a `.intent` file
suffix.

`disable_intent()` is updated for symmetry: it now unbinds both events. It
previously did not unbind the handler at all when disabling an intent (a
pre-existing gap now more visible with two live bindings). `detach()` was
left as-is -- it already relies on `default_shutdown()`'s `self.events.clear()`
to unbind everything.

## Tests

Added to `test/unittests/skills/test_base.py`:
- `test_register_intent_file_binds_canonical_and_legacy_events` -- registering
  an intent file binds handlers on both topics.
- `test_register_intent_file_canonical_topic_fires_handler` -- emitting the
  canonical topic on the bus fires the handler.
- `test_disable_intent_removes_both_events` -- disabling removes both
  bindings.

Full workshop suite (fresh venv, `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest
test/ -v`): **560 passed**, no failures.

## Full-chain end-to-end proof

In `~/.venvs/core-alpha-bump` with this worktree AND the
padatious-pipeline#89 worktree both installed (`uv pip install -e <path>`
each), ran `pytest test/end2end/test_padatious.py -v` from ovos-core's
`bump-latest-alphas` worktree: handler dispatch now fires (no more timeout on
`test_padatious_match`). A separate, pre-existing assertion in ovos-core's
own e2e test hardcoded the *legacy* `intent_name` in the expected
`ovos.utterance.handled` payload; that expectation is being corrected in the
ovos-core worktree alongside this PR (see OpenVoiceOS/ovos-core#831) to match
the canonical name the system now reports once dispatch happens on the
canonical topic.

## Merge order

This PR is a no-op dual-bind on its own -- the "dispatch happens on the
canonical topic" behavior only exists once
OpenVoiceOS/ovos-padatious-pipeline-plugin#89 and OpenVoiceOS/padacioso#73
land. **This must merge and publish together with those two PRs**, and
ovos-core#831 tracks the companion `intent_name` expectation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Intent handlers now respond reliably through both legacy and canonical dispatch routes.
  * Disabling an intent now removes all associated event bindings, preventing unintended handler activation.

* **Tests**
  * Added coverage verifying registration, canonical-topic dispatch, and complete intent disabling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->