### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -1,6 +1,6 @@
 # OVOSAbstractApplication
 
-`OVOSAbstractApplication` is a skill-like class designed to run **without** an intent service. Use it for standalone GUI apps, HiveMind-attached services, or any program that needs access to TTS, the MessageBus, and settings — but does not need to register intents with `ovos-core`.
+`OVOSAbstractApplication` is a skill-like class designed to run **without** an intent service. Use it for standalone GUI apps, HiveMind-attached services, or any program that needs access to TTS, the MessageBus, and settings, but does not need to register intents with `ovos-core`.
 
 **Source:** `ovos_workshop/app.py`
 
@@ -33,8 +33,7 @@ class OVOSAbstractApplication(OVOSSkill):
     ): ...
 ```
 
-`OVOSAbstractApplication.__init__` — `ovos_workshop/app.py:13`
-
+`OVOSAbstractApplication.__init__` is defined in `ovos_workshop/app.py:13`.
 ### Parameters
 
 | Parameter | Type | Description |
@@ -48,8 +47,7 @@ class OVOSAbstractApplication(OVOSSkill):
 
 ## `_dedicated_bus` Flag
 
-`OVOSAbstractApplication._dedicated_bus` — `ovos_workshop/app.py:25`
-
+`OVOSAbstractApplication._dedicated_bus` is defined in `ovos_workshop/app.py:25`.
 Set to `True` when the application created its own bus connection (i.e., `bus=None` was passed to `__init__`). The flag is used in `default_shutdown()` to decide whether to close the bus on exit.
 
 ```python
@@ -65,8 +63,7 @@ else:
 
 ## `settings_path` Property
 
-`OVOSAbstractApplication.settings_path` — `ovos_workshop/app.py:36`
-
+`OVOSAbstractApplication.settings_path` is defined in `ovos_workshop/app.py:36`.
 Returns the path where this application's settings file is stored. Unlike `OVOSSkill`, which stores settings under `~/.config/ovos/skills/`, applications store settings under `apps/`:
 
 ```
@@ -79,8 +76,7 @@ This separation prevents skill managers from scanning and accidentally loading a
 
 ## `default_shutdown()`
 
-`OVOSAbstractApplication.default_shutdown` — `ovos_workshop/app.py:43`
-
+`OVOSAbstractApplication.default_shutdown` is defined in `ovos_workshop/app.py:43`.
 Gracefully shuts down the application:
 
 1. Calls `self.clear_intents()` to remove all bus handlers and detach from the intent service.
@@ -99,8 +95,7 @@ def default_shutdown(self):
 
 ## `get_language_dir()`
 
-`OVOSAbstractApplication.get_language_dir` — `ovos_workshop/app.py:52`
-
+`OVOSAbstractApplication.get_language_dir` is defined in `ovos_workshop/app.py:52`.
 Returns the best-matched language resource directory for the requested language, with **dialect fallback**. For example, if `lang="pt-pt"` is requested but only `pt-br` resources exist, the `pt-br` path is returned.
 
 ```python
@@ -118,9 +113,9 @@ def get_language_dir(
 
 **Lookup order** (`ovos_workshop/app.py:69`):
 
-1. `<base_path>/<lang>` — exact match with region in upper case (e.g. `en-US`)
-2. `<base_path>/<lang.lower()>` — exact match lower-cased (e.g. `en-us`)
-3. Dialect siblings via `locate_lang_directories()` — sorted by similarity, first match wins.
+1. `<base_path>/<lang>`: exact match with region in upper case (e.g. `en-US`)
+2. `<base_path>/<lang.lower()>`: exact match lower-cased (e.g. `en-us`)
+3. Dialect siblings via `locate_lang_directories()`: sorted by similarity, first match wins.
 
 Returns `None` if no matching directory is found.
 
@@ -128,8 +123,7 @@ Returns `None` if no matching directory is found.
 
 ## `clear_intents()`
 
-`OVOSAbstractApplication.clear_intents` — `ovos_workshop/app.py:83`
-
+`OVOSAbstractApplication.clear_intents` is defined in `ovos_workshop/app.py:83`.
 Removes all registered event handlers for this application's intents and detaches the application from the intent service. This prevents duplicate handlers if the application is re-initialized without a full process restart.
 
 ```python
@@ -180,5 +174,8 @@ bus = MessageBusClient()
 bus.run_in_thread()
 
 app = MyClockApp(bus=bus)
-# _dedicated_bus is False — shutdown will NOT close the bus.
+# _dedicated_bus is False: shutdown will NOT close the bus.
 ```
+
+---
+[← decorators](decorators.md) · [Home](index.md) · [game-skill →](game-skill.md)

--- a/docs/auto-translatable.md
+++ b/docs/auto-translatable.md
@@ -12,8 +12,8 @@ Normal skills receive utterances in whatever language the user spoke (`self.lang
 
 `UniversalSkill` breaks this into two clear responsibilities:
 
-1. **Input translation** — Before each intent handler fires, the incoming `Message` is translated so that `message.data["utterances"]` and related fields are in `self.internal_language`.
-2. **Output translation** — Every call to `self.speak()` translates the text from `self.internal_language` back to `self.lang` (the user's language).
+1. **Input translation**: Before each intent handler fires, the incoming `Message` is translated so that `message.data["utterances"]` and related fields are in `self.internal_language`.
+2. **Output translation**: Every call to `self.speak()` translates the text from `self.internal_language` back to `self.lang` (the user's language).
 
 The translation is performed by the configured translator plugin (set in `ovos.conf`). `self.lang` always reflects the **original query language** from the session.
 
@@ -21,8 +21,7 @@ The translation is performed by the configured translator plugin (set in `ovos.c
 
 ## UniversalSkill
 
-`UniversalSkill` — `ovos_workshop/skills/auto_translatable.py:14`
-
+`UniversalSkill` is defined in `ovos_workshop/skills/auto_translatable.py:14`.
 ### Constructor
 
 ```python
@@ -38,8 +37,7 @@ class UniversalSkill(OVOSSkill):
     ): ...
 ```
 
-`UniversalSkill.__init__` — `ovos_workshop/skills/auto_translatable.py:30`
-
+`UniversalSkill.__init__` is defined in `ovos_workshop/skills/auto_translatable.py:30`.
 | Parameter | Default | Description |
 |---|---|---|
 | `internal_language` | `None` (falls back to `config["lang"]`) | The language in which the skill internally operates. All handlers receive utterances in this language. |
@@ -53,8 +51,7 @@ If `internal_language` is not given, a warning is logged and the global config l
 
 ### `internal_language`
 
-`UniversalSkill.internal_language` — `ovos_workshop/skills/auto_translatable.py:53`
-
+`UniversalSkill.internal_language` is defined in `ovos_workshop/skills/auto_translatable.py:53`.
 The language tag the skill expects to receive and produce. Set this in your subclass constructor:
 
 ```python
@@ -65,22 +62,20 @@ super().__init__(internal_language="en-US", *args, **kwargs)
 
 ### `detect_language(utterance)`
 
-`UniversalSkill.detect_language` — `ovos_workshop/skills/auto_translatable.py:79`
-
+`UniversalSkill.detect_language` is defined in `ovos_workshop/skills/auto_translatable.py:79`.
 Detects the language of `utterance` using the configured language detector plugin. Falls back to `self.lang.split("-")[0]` on error.
 
 ```python
 def detect_language(self, utterance: str) -> str: ...
 ```
 
-Only active when `autodetect=True`; otherwise `self.lang` (from the session) is used as the source language.
+Only active when `autodetect=True`. Otherwise `self.lang` (from the session) is used as the source language.
 
 ---
 
 ### `translate_utterance(text, target_lang, sauce_lang=None)`
 
-`UniversalSkill.translate_utterance` — `ovos_workshop/skills/auto_translatable.py:104`
-
+`UniversalSkill.translate_utterance` is defined in `ovos_workshop/skills/auto_translatable.py:104`.
 Translates `text` from `sauce_lang` to `target_lang`. If the source and target language share the same base code (ignoring region), the original text is returned unchanged.
 
 ```python
@@ -98,8 +93,7 @@ If `autodetect=True`, `sauce_lang` is determined by calling `detect_language(tex
 
 ### `translate_message(message)`
 
-`UniversalSkill.translate_message` — `ovos_workshop/skills/auto_translatable.py:134`
-
+`UniversalSkill.translate_message` is defined in `ovos_workshop/skills/auto_translatable.py:134`.
 Translates the full message in-place (or returns it unchanged if no translation is needed). The method:
 
 1. Sets `sauce_lang = self.lang` and `out_lang = self.internal_language`.
@@ -114,10 +108,9 @@ Returns the modified `Message`.
 
 ### Overridden `register_intent()` and `register_intent_file()`
 
-`UniversalSkill.register_intent` — `ovos_workshop/skills/auto_translatable.py:228`
-`UniversalSkill.register_intent_file` — `ovos_workshop/skills/auto_translatable.py:250`
-
-Both methods wrap the provided handler with `create_universal_handler()` before passing it to the parent class. This is transparent — you register intents exactly as with a regular `OVOSSkill`:
+`UniversalSkill.register_intent` is defined in `ovos_workshop/skills/auto_translatable.py:228`.
+`UniversalSkill.register_intent_file` is defined in `ovos_workshop/skills/auto_translatable.py:250`.
+Both methods wrap the provided handler with `create_universal_handler()` before passing it to the parent class. This is transparent: you register intents exactly as with a regular `OVOSSkill`:
 
 ```python
 def initialize(self):
@@ -130,8 +123,7 @@ The handler will always receive `message.data["utterances"]` in `self.internal_l
 
 ### `create_universal_handler(handler)`
 
-`UniversalSkill.create_universal_handler` — `ovos_workshop/skills/auto_translatable.py:193`
-
+`UniversalSkill.create_universal_handler` is defined in `ovos_workshop/skills/auto_translatable.py:193`.
 Creates a wrapper that calls `self.translate_message(message)` before calling `handler(message)`. Use this explicitly only when registering handlers with `self.add_event()` (not with `register_intent`, which wraps automatically):
 
 ```python
@@ -146,8 +138,7 @@ def initialize(self):
 
 ### Overridden `speak()`
 
-`UniversalSkill.speak` — `ovos_workshop/skills/auto_translatable.py:272`
-
+`UniversalSkill.speak` is defined in `ovos_workshop/skills/auto_translatable.py:272`.
 Translates the utterance from `self.internal_language` to `self.lang` before calling `super().speak()`. Translation metadata is stored in the `meta` kwarg:
 
 ```python
@@ -163,8 +154,7 @@ meta["translation_data"] = {
 
 ## UniversalFallback
 
-`UniversalFallback` — `ovos_workshop/skills/auto_translatable.py:314`
-
+`UniversalFallback` is defined in `ovos_workshop/skills/auto_translatable.py:314`.
 ```python
 class UniversalFallback(UniversalSkill, FallbackSkill):
     ...
@@ -174,22 +164,19 @@ Combines `UniversalSkill` with `FallbackSkill`. Fallback handlers receive uttera
 
 ### `register_fallback(handler, priority)`
 
-`UniversalFallback.register_fallback` — `ovos_workshop/skills/auto_translatable.py:353`
-
+`UniversalFallback.register_fallback` is defined in `ovos_workshop/skills/auto_translatable.py:353`.
 Wraps the handler with `create_universal_fallback_handler()` before registering it, ensuring translation happens before the handler is called.
 
 ### `create_universal_fallback_handler(handler)`
 
-`UniversalFallback.create_universal_fallback_handler` — `ovos_workshop/skills/auto_translatable.py:328`
-
+`UniversalFallback.create_universal_fallback_handler` is defined in `ovos_workshop/skills/auto_translatable.py:328`.
 Similar to `create_universal_handler()` but designed for fallback handlers (which receive `self` as an explicit argument).
 
 ---
 
 ## UniversalCommonQuerySkill
 
-`UniversalCommonQuerySkill` — `ovos_workshop/skills/auto_translatable.py:376`
-
+`UniversalCommonQuerySkill` is defined in `ovos_workshop/skills/auto_translatable.py:376`.
 > **Deprecated.** Use `UniversalSkill` with `@common_query` instead.
 
 Combines `UniversalSkill` with `CommonQuerySkill`. Both the input phrase and the skill's answer are translated automatically:
@@ -224,7 +211,7 @@ class WeatherSkill(UniversalSkill):
     def handle_weather(self, message):
         # message.data["utterances"][0] is already in English here.
         city = message.data.get("city", "your location")
-        # self.lang is still the original user language — useful for logging.
+        # self.lang is still the original user language, useful for logging.
         self.log.debug(f"User language: {self.lang}")
         # speak() translates from en-US → self.lang automatically.
         self.speak(f"The weather in {city} is sunny today.")
@@ -249,3 +236,6 @@ class MyUniversalFallback(UniversalFallback):
         self.speak(f"I heard: {utterance}")
         return True
 ```
+
+---
+[← game-skill](game-skill.md) · [Home](index.md) · [skill-interaction →](skill-interaction.md)

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -41,8 +41,7 @@ from ovos_workshop.decorators.ocp import (
 
 ### `@intent_handler`
 
-`intent_handler` — `ovos_workshop/decorators/__init__.py:57`
-
+`intent_handler` is defined in `ovos_workshop/decorators/__init__.py:57`.
 Register a method as a Padatious (`.intent` file) or Adapt (`IntentBuilder`) intent handler.
 
 ```python
@@ -57,7 +56,7 @@ def handle_my(self, message): ...
 @intent_handler(IntentBuilder("GreetIntent").require("Hello"))
 def handle_greet(self, message): ...
 
-# With voc blacklist — suppress adapt keywords in this handler
+# With voc blacklist: suppress adapt keywords in this handler
 @intent_handler("my.intent", voc_blacklist=["StopKeyword"])
 def handle_my_no_stop(self, message): ...
 ```
@@ -68,8 +67,7 @@ A method can have multiple `@intent_handler` decorators to handle multiple inten
 
 ### `@conversational_intent`
 
-`conversational_intent` — `ovos_workshop/decorators/__init__.py:117`
-
+`conversational_intent` is defined in `ovos_workshop/decorators/__init__.py:117`.
 Register a Padatious `.intent` file as a converse-only matcher. Only active when the skill is in converse mode. Requires the skill to extend `ConversationalSkill`.
 
 > **Note:** Only Padatious intents are supported, not Adapt.
@@ -85,8 +83,7 @@ def handle_help_in_converse(self, message): ...
 
 ### `@fallback_handler`
 
-`fallback_handler` — `ovos_workshop/decorators/__init__.py:133`
-
+`fallback_handler` is defined in `ovos_workshop/decorators/__init__.py:133`.
 Register a method as a fallback handler with a given priority (0–100, lower = higher priority).
 
 ```python
@@ -95,15 +92,14 @@ from ovos_workshop.decorators import fallback_handler
 @fallback_handler(priority=50)
 def handle_unknown(self, message):
     self.speak("I don't know.")
-    return True  # consumed — stop checking other fallbacks
+    return True  # consumed: stop checking other fallbacks
 ```
 
 ---
 
 ### `@common_query`
 
-`common_query` — `ovos_workshop/decorators/__init__.py:94`
-
+`common_query` is defined in `ovos_workshop/decorators/__init__.py:94`.
 Register a method as a CommonQuery handler. The method must return `(answer, confidence)` or `None`.
 
 ```python
@@ -124,8 +120,7 @@ def handle_query(self, phrase, lang):
 
 ### `@converse_handler`
 
-`converse_handler` — `ovos_workshop/decorators/__init__.py:108`
-
+`converse_handler` is defined in `ovos_workshop/decorators/__init__.py:108`.
 Alias a method as the skill's `converse` handler instead of overriding `converse()` directly.
 
 ```python
@@ -140,9 +135,8 @@ def my_converse(self, message):
 
 ## Context Decorators
 
-`adds_context` — `ovos_workshop/decorators/__init__.py:16`
-`removes_context` — `ovos_workshop/decorators/__init__.py:37`
-
+`adds_context` is defined in `ovos_workshop/decorators/__init__.py:16`.
+`removes_context` is defined in `ovos_workshop/decorators/__init__.py:37`.
 These run **after** the decorated method completes.
 
 ### `@adds_context`
@@ -171,22 +165,21 @@ def handle_cancel(self, message):
 
 ### Exception Classes
 
-`AbortEvent` — `ovos_workshop/decorators/killable.py:12`
-`AbortIntent` — `ovos_workshop/decorators/killable.py:16`
-`AbortQuestion` — `ovos_workshop/decorators/killable.py:19`
-
+`AbortEvent` is defined in `ovos_workshop/decorators/killable.py:12`.
+`AbortIntent` is defined in `ovos_workshop/decorators/killable.py:16`.
+`AbortQuestion` is defined in `ovos_workshop/decorators/killable.py:19`.
 ```python
 class AbortEvent(StopIteration):
-    """Base class — abort any bus event handler."""
+    """Base class: abort any bus event handler."""
 
 class AbortIntent(AbortEvent):
-    """Abort intent parsing; raised by @killable_intent."""
+    """Abort intent parsing. Raised by @killable_intent."""
 
 class AbortQuestion(AbortEvent):
     """Gracefully abort get_response queries."""
 ```
 
-These exceptions are **raised inside the handler thread** when the kill message is received. They propagate through the call stack; wrap long-running loops to catch and clean up:
+These exceptions are **raised inside the handler thread** when the kill message is received. They propagate through the call stack. Wrap long-running loops to catch and clean up:
 
 ```python
 from ovos_workshop.decorators.killable import killable_intent, AbortIntent
@@ -205,8 +198,7 @@ def handle_long_task(self, message):
 
 ### `@killable_intent`
 
-`killable_intent` — `ovos_workshop/decorators/killable.py:24`
-
+`killable_intent` is defined in `ovos_workshop/decorators/killable.py:24`.
 Mark an intent handler that can be interrupted mid-execution. Spawns the handler in a daemon thread. When the kill message arrives:
 
 1. Optionally emits `mycroft.audio.speech.stop` (if `stop_tts=True`).
@@ -256,8 +248,7 @@ Bus receives "mycroft.skills.abort_execution"
 
 ### `@killable_event`
 
-`killable_event` — `ovos_workshop/decorators/killable.py:40`
-
+`killable_event` is defined in `ovos_workshop/decorators/killable.py:40`.
 Like `@killable_intent` but for any bus event handler. Does **not** react to stop messages or call `skill.stop()` by default.
 
 ```python
@@ -287,8 +278,7 @@ Intent layers let you enable or disable groups of intents at runtime, implementi
 
 ### `@layer_intent`
 
-`layer_intent` — `ovos_workshop/decorators/layers.py:128`
-
+`layer_intent` is defined in `ovos_workshop/decorators/layers.py:128`.
 Register an intent handler that belongs to a named layer. The intent is disabled until the layer is activated.
 
 ```python
@@ -303,9 +293,8 @@ def handle_move(self, message): ...
 
 ### `@enables_layer` / `@disables_layer`
 
-`enables_layer` — `ovos_workshop/decorators/layers.py:33`
-`disables_layer` — `ovos_workshop/decorators/layers.py:52`
-
+`enables_layer` is defined in `ovos_workshop/decorators/layers.py:33`.
+`disables_layer` is defined in `ovos_workshop/decorators/layers.py:52`.
 Activate or deactivate a named intent layer **after** the decorated method runs.
 
 ```python
@@ -324,8 +313,7 @@ def stop_game_intent(self, message):
 
 ### `@replaces_layer`
 
-`replaces_layer` — `ovos_workshop/decorators/layers.py:71`
-
+`replaces_layer` is defined in `ovos_workshop/decorators/layers.py:71`.
 Replace the intent list of a named layer after the method runs.
 
 ```python
@@ -339,8 +327,7 @@ def transition(self, message): ...
 
 ### `@removes_layer`
 
-`removes_layer` — `ovos_workshop/decorators/layers.py:91`
-
+`removes_layer` is defined in `ovos_workshop/decorators/layers.py:91`.
 Remove a named layer entirely (and disable its intents) after the method runs.
 
 ```python
@@ -354,8 +341,7 @@ def finish_flow(self, message): ...
 
 ### `@resets_layers`
 
-`resets_layers` — `ovos_workshop/decorators/layers.py:110`
-
+`resets_layers` is defined in `ovos_workshop/decorators/layers.py:110`.
 Disable **all** intent layers after the method runs.
 
 ```python
@@ -372,8 +358,7 @@ def reset_everything(self, message):
 
 ### `@homescreen_app`
 
-`homescreen_app` — `ovos_workshop/decorators/__init__.py:149`
-
+`homescreen_app` is defined in `ovos_workshop/decorators/__init__.py:149`.
 Register a method as a homescreen app launcher. The icon file must be inside the `gui/` subfolder of the skill.
 
 ```python
@@ -390,8 +375,7 @@ def launch_app(self, message):
 
 ### `@skill_api_method`
 
-`skill_api_method` — `ovos_workshop/decorators/__init__.py:77`
-
+`skill_api_method` is defined in `ovos_workshop/decorators/__init__.py:77`.
 Expose a method over the bus so other skills or applications can call it via `SkillApi`. See [skill-api.md](skill-api.md) for the full RPC documentation.
 
 ```python
@@ -415,7 +399,7 @@ OCP (OpenVoiceOS Common Play) decorators are used with `OVOSCommonPlaybackSkill`
 
 | Decorator | Attribute set | Description | Source line |
 |---|---|---|---|
-| `@ocp_search()` | `is_ocp_search_handler` | Search for playable content; yield/return `MediaEntry` results. | `ocp.py:5` |
+| `@ocp_search()` | `is_ocp_search_handler` | Search for playable content. Yield or return `MediaEntry` results. | `ocp.py:5` |
 | `@ocp_play()` | `is_ocp_playback_handler` | Handle a play request (start playback). | `ocp.py:34` |
 | `@ocp_pause()` | `is_ocp_pause_handler` | Handle a pause request. | `ocp.py:82` |
 | `@ocp_resume()` | `is_ocp_resume_handler` | Handle a resume request. | `ocp.py:98` |
@@ -485,3 +469,6 @@ def handle_confirm(self, message):
     self.speak("Order confirmed.")
 # Context is added AFTER handle_confirm() returns.
 ```
+
+---
+[← ovos-skill](ovos-skill.md) · [Home](index.md) · [app →](app.md)

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -1,4 +1,4 @@
-# FileSystemAccess — Sandboxed Skill File I/O
+# FileSystemAccess: Sandboxed Skill File I/O
 
 `FileSystemAccess` provides each skill with an isolated, XDG-compliant directory for persistent file storage. It prevents skills from accidentally writing to arbitrary locations and handles migration from legacy Mycroft paths.
 
@@ -8,8 +8,7 @@
 
 ## Storage Path
 
-`FileSystemAccess.__init_path` — `ovos_workshop/filesystem.py:34`
-
+`FileSystemAccess.__init_path` is defined in `ovos_workshop/filesystem.py:34`.
 Files are stored under:
 
 ```
@@ -24,8 +23,7 @@ The directory is created automatically if it does not exist.
 
 ## Migration from Old Paths
 
-`FileSystemAccess.__init_path` — `ovos_workshop/filesystem.py:43`
-
+`FileSystemAccess.__init_path` is defined in `ovos_workshop/filesystem.py:43`.
 If a directory exists at the legacy Mycroft location (`~/.mycroft/<skill_id>`) but the XDG path does not yet exist, the directory is automatically **moved** to the new location:
 
 ```python
@@ -46,8 +44,7 @@ class FileSystemAccess:
     def __init__(self, path: str): ...
 ```
 
-`FileSystemAccess.__init__` — `ovos_workshop/filesystem.py:26`
-
+`FileSystemAccess.__init__` is defined in `ovos_workshop/filesystem.py:26`.
 | Parameter | Description |
 |---|---|
 | `path` | Base name for the skill's directory (typically the `skill_id`). Must be a non-empty string. |
@@ -62,8 +59,7 @@ After construction, `self.path` holds the absolute path to the skill's storage d
 
 ### `open(filename, mode)`
 
-`FileSystemAccess.open` — `ovos_workshop/filesystem.py:54`
-
+`FileSystemAccess.open` is defined in `ovos_workshop/filesystem.py:54`.
 Open a file inside the skill's sandboxed directory. Equivalent to `open(skill_dir / filename, mode)`.
 
 ```python
@@ -79,8 +75,7 @@ Returns a file object.
 
 ### `exists(filename)`
 
-`FileSystemAccess.exists` — `ovos_workshop/filesystem.py:64`
-
+`FileSystemAccess.exists` is defined in `ovos_workshop/filesystem.py:64`.
 Check whether a file exists inside the skill's sandboxed directory.
 
 ```python
@@ -158,3 +153,6 @@ if not fs.exists("config.json"):
         import json
         json.dump({"initialized": True}, f)
 ```
+
+---
+[← skill-api](skill-api.md) · [Home](index.md) · [resource-files →](resource-files.md)

--- a/docs/game-skill.md
+++ b/docs/game-skill.md
@@ -11,7 +11,7 @@
 ```text
 OVOSSkill
 └── OVOSCommonPlaybackSkill
-    └── OVOSGameSkill                  # abstract — OCP-integrated game loop
+    └── OVOSGameSkill                  # abstract: OCP-integrated game loop
         └── ConversationalGameSkill    # adds converse loop + auto-save
 ```
 
@@ -21,8 +21,7 @@ OVOSSkill
 
 ## OVOSGameSkill
 
-`OVOSGameSkill` — `ovos_workshop/skills/game_skill.py:14`
-
+`OVOSGameSkill` is defined in `ovos_workshop/skills/game_skill.py:14`.
 ### Constructor
 
 ```python
@@ -37,8 +36,7 @@ class OVOSGameSkill(OVOSCommonPlaybackSkill):
     ): ...
 ```
 
-`OVOSGameSkill.__init__` — `ovos_workshop/skills/game_skill.py:33`
-
+`OVOSGameSkill.__init__` is defined in `ovos_workshop/skills/game_skill.py:33`.
 | Parameter | Description |
 |---|---|
 | `skill_voc_filename` | **Required.** Name of the `.voc` file containing keywords that match the game name. Without this, OCP cannot recognize the skill as a game. |
@@ -56,7 +54,7 @@ Subclasses **must** implement all six abstract methods:
 | `on_play_game()` | OCP pipeline selected this game and started playback. | `ovos_workshop/skills/game_skill.py:94` |
 | `on_pause_game()` | OCP `pause` command while game is playing. | `ovos_workshop/skills/game_skill.py:98` |
 | `on_resume_game()` | OCP `resume`/`unpause` while game is paused. | `ovos_workshop/skills/game_skill.py:102` |
-| `on_stop_game()` | Game stopped for any reason; implement auto-save here if desired. | `ovos_workshop/skills/game_skill.py:106` |
+| `on_stop_game()` | Game stopped for any reason. Implement auto-save here if desired. | `ovos_workshop/skills/game_skill.py:106` |
 | `on_save_game()` | Explicit save request. Speak an error dialog if save is not supported. | `ovos_workshop/skills/game_skill.py:111` |
 | `on_load_game()` | Explicit load request. Speak an error dialog if load is not supported. | `ovos_workshop/skills/game_skill.py:116` |
 
@@ -64,8 +62,7 @@ Subclasses **must** implement all six abstract methods:
 
 #### `is_playing`
 
-`OVOSGameSkill.is_playing` — `ovos_workshop/skills/game_skill.py:87`
-
+`OVOSGameSkill.is_playing` is defined in `ovos_workshop/skills/game_skill.py:87`.
 Returns `True` when the game is actively running (OCP player state is not stopped/paused).
 
 ```python
@@ -76,8 +73,7 @@ def is_playing(self) -> bool:
 
 #### `is_paused`
 
-`OVOSGameSkill.is_paused` — `ovos_workshop/skills/game_skill.py:91`
-
+`OVOSGameSkill.is_paused` is defined in `ovos_workshop/skills/game_skill.py:91`.
 Returns `True` when the game is in the paused state.
 
 ```python
@@ -88,11 +84,10 @@ def is_paused(self) -> bool:
 
 ### `stop_game()`
 
-`OVOSGameSkill.stop_game` — `ovos_workshop/skills/game_skill.py:121`
-
+`OVOSGameSkill.stop_game` is defined in `ovos_workshop/skills/game_skill.py:121`.
 Call this from within your skill code when you need to programmatically stop the game (e.g. the player lost). It:
 
-1. Checks `is_playing`; returns `False` immediately if not playing.
+1. Checks `is_playing`, returns `False` immediately if not playing.
 2. Clears the paused flag.
 3. Releases the GUI.
 4. Emits `ovos.common_play.player.state` with `PlayerState.STOPPED`.
@@ -103,8 +98,7 @@ Returns `True` if the game was stopped, `False` if it was already stopped.
 
 ### `calc_intent()`
 
-`OVOSGameSkill.calc_intent` — `ovos_workshop/skills/game_skill.py:138`
-
+`OVOSGameSkill.calc_intent` is defined in `ovos_workshop/skills/game_skill.py:138`.
 Helper that asks `ovos-core` which intent it would select for a given utterance. Useful in `converse()` to decide whether to let the intent pipeline handle the utterance or pipe it to the game.
 
 ```python
@@ -122,8 +116,7 @@ Returns the intent dict from `ovos-core`, or `None` on timeout.
 
 ## ConversationalGameSkill
 
-`ConversationalGameSkill` — `ovos_workshop/skills/game_skill.py:151`
-
+`ConversationalGameSkill` is defined in `ovos_workshop/skills/game_skill.py:151`.
 Extends `OVOSGameSkill` with a **converse loop**: every utterance that does not match a registered intent is piped to `on_game_command()` while the game is playing.
 
 ### Additional Abstract Methods
@@ -149,14 +142,12 @@ The pause/resume dialogs are controlled by `settings["pause_dialog"]` (default `
 
 ### `on_abandon_game()`
 
-`ConversationalGameSkill.on_abandon_game` — `ovos_workshop/skills/game_skill.py:197`
-
+`ConversationalGameSkill.on_abandon_game` is defined in `ovos_workshop/skills/game_skill.py:197`.
 Called when the user stops interacting with the game long enough for the intent service to deactivate this skill. Auto-save runs before this method (if enabled). Override to play a farewell message or clean up state. `on_stop_game()` is called after this handler.
 
 ### `save_is_implemented` Property
 
-`ConversationalGameSkill.save_is_implemented` — `ovos_workshop/skills/game_skill.py:223`
-
+`ConversationalGameSkill.save_is_implemented` is defined in `ovos_workshop/skills/game_skill.py:223`.
 Returns `True` if the subclass has overridden `on_save_game()` (i.e. save is actually implemented). Used by `_autosave()` to skip auto-save for games that cannot save.
 
 ```python
@@ -167,8 +158,7 @@ def save_is_implemented(self) -> bool:
 
 ### Auto-save
 
-`ConversationalGameSkill._autosave` — `ovos_workshop/skills/game_skill.py:229`
-
+`ConversationalGameSkill._autosave` is defined in `ovos_workshop/skills/game_skill.py:229`.
 Automatically saves the game if **both** conditions are met:
 
 - `settings["auto_save"]` is `True` (default `False`).
@@ -181,8 +171,7 @@ Auto-save is triggered in three places:
 
 ### `skill_will_trigger()`
 
-`ConversationalGameSkill.skill_will_trigger` — `ovos_workshop/skills/game_skill.py:206`
-
+`ConversationalGameSkill.skill_will_trigger` is defined in `ovos_workshop/skills/game_skill.py:206`.
 Checks whether this skill's intents would be selected by `ovos-core` for the given utterance. Useful in `converse()` to avoid double-handling:
 
 ```python
@@ -248,3 +237,6 @@ Enable auto-save in `settings.json`:
   "pause_dialog": true
 }
 ```
+
+---
+[← app](app.md) · [Home](index.md) · [auto-translatable →](auto-translatable.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ OVOSSkill                             ovos_workshop/skills/ovos.py
 | [skill-api.md](skill-api.md) | `SkillApi`, `skill_api_method` | Inter-skill RPC over the MessageBus |
 | [filesystem.md](filesystem.md) | `FileSystemAccess` | Sandboxed, XDG-compliant file storage for skills |
 | [resource-files.md](resource-files.md) | `SkillResources` | Locale, dialog, vocab, regex, and other resource files |
-| [settings.md](settings.md) | `SkillSettingsManager` | Skill settings — persistence, change callbacks, file watching |
+| [settings.md](settings.md) | `SkillSettingsManager` | Skill settings: persistence, change callbacks, file watching |
 | [intent-layers.md](intent-layers.md) | `IntentLayers` | Enable/disable intent sets at runtime |
 | [skill-launcher.md](skill-launcher.md) | `SkillLoader`, `PluginSkillLoader` | Loading skills as plugins or in standalone mode |
 | [permissions.md](permissions.md) | `ConverseMode`, `FallbackMode` | Converse and fallback permission modes |
@@ -87,9 +87,9 @@ OVOS uses a WebSocket publish/subscribe bus. Every message has three fields:
 
 ```python
 Message(
-    msg_type="my.event.type",   # str — event name
-    data={"key": "value"},      # dict — payload
-    context={"session_id": ...} # dict — metadata
+    msg_type="my.event.type",   # str: event name
+    data={"key": "value"},      # dict: payload
+    context={"session_id": ...} # dict: metadata
 )
 ```
 
@@ -114,10 +114,10 @@ Resource files live in the skill's `locale/` directory, organized by language ta
 ```
 locale/
   en-us/
-    dialog/   # .dialog files — spoken responses
-    vocab/    # .voc files — keyword lists for Adapt
-    intent/   # .intent files — Padatious training phrases
-    regex/    # .rx files — named-entity patterns
+    dialog/   # .dialog files: spoken responses
+    vocab/    # .voc files: keyword lists for Adapt
+    intent/   # .intent files: Padatious training phrases
+    regex/    # .rx files: named-entity patterns
 ```
 
 Access via `self.speak_dialog("my.response")`, `self.get_response()`, etc.
@@ -127,8 +127,8 @@ See [resource-files.md](resource-files.md).
 
 Two intent engines are supported:
 
-- **Adapt** — keyword-based, uses `IntentBuilder` and `.voc` files.
-- **Padatious** — ML phrase-matching, uses `.intent` files.
+- **Adapt**: keyword-based, uses `IntentBuilder` and `.voc` files.
+- **Padatious**: ML phrase-matching, uses `.intent` files.
 
 Register intents with `@intent_handler` or `self.register_intent()`.
 See [decorators.md](decorators.md) and [ovos-skill.md](ovos-skill.md).

--- a/docs/intent-layers.md
+++ b/docs/intent-layers.md
@@ -6,7 +6,7 @@ Intent layers let a skill enable or disable groups of intents at runtime. This i
 
 ## Concept
 
-A skill can define multiple named "layers", each containing a set of intents. Only the intents belonging to the currently active layer(s) are enabled at any time. The skill starts with no layers active — the global (non-layered) intents are always active.
+A skill can define multiple named "layers", each containing a set of intents. Only the intents belonging to the currently active layer(s) are enabled at any time. The skill starts with no layers active: the global (non-layered) intents are always active.
 
 ## Using Decorators
 
@@ -113,3 +113,6 @@ self.register_intent_layer("my_layer", [
 ```
 
 This registers the intents without activating the layer. Call `activate_layer` to enable them.
+
+---
+[← settings](settings.md) · [Home](index.md) · [skill-launcher →](skill-launcher.md)

--- a/docs/ovos-skill.md
+++ b/docs/ovos-skill.md
@@ -34,7 +34,7 @@ Override these in your skill class:
 | `initialize()` | After full startup | Legacy. Prefer `__init__`. |
 | `get_intro_message()` | First run only | Return a dialog name or string to speak on first install |
 | `stop()` | User/system stop | Return `True` if the skill handled the stop |
-| `stop_session(session)` | Per-session stop | Called before `stop()`; return `True` to prevent global `stop()` |
+| `stop_session(session)` | Per-session stop | Called before `stop()`. Return `True` to prevent global `stop()` |
 | `can_stop(message)` | Before stop | Must be implemented if `stop()` or `stop_session()` is defined |
 | `shutdown()` | Skill unload | Final cleanup after all other shutdown steps |
 
@@ -187,3 +187,6 @@ This is used by `SkillManager` to defer loading until the required connectivity 
 | `question:action.{skill_id}` | Common query callback |
 | `homescreen.metadata.get` | Homescreen requesting metadata |
 | `{skill_id}.public_api` | Skill API introspection |
+
+---
+[← skill-classes](skill-classes.md) · [Home](index.md) · [decorators →](decorators.md)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -102,3 +102,6 @@ whitelist_skill("my-unwanted-skill-id")
 ```
 
 These functions directly modify `mycroft.conf` and take effect on the next skill manager reload.
+
+---
+[← skill-launcher](skill-launcher.md) · [Home](index.md)

--- a/docs/resource-files.md
+++ b/docs/resource-files.md
@@ -23,7 +23,7 @@ my-skill/
     └── my_page.qml
 ```
 
-Legacy skills may use separate `dialog/`, `vocab/`, `regex/` subdirectories — these are still supported.
+Legacy skills may use separate `dialog/`, `vocab/`, `regex/` subdirectories: these are still supported.
 
 ## Resource Types
 
@@ -129,3 +129,6 @@ Optional file for homescreen integration. Placed at `locale/<lang>/skill.json`:
 ```
 
 These examples are emitted to the homescreen as `homescreen.register.examples` on skill startup.
+
+---
+[← filesystem](filesystem.md) · [Home](index.md) · [settings →](settings.md)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -28,7 +28,7 @@ self.settings["username"] = "Alice"
 self.settings.store()
 ```
 
-Do not replace the whole `self.settings` dict — update individual keys:
+Do not replace the whole `self.settings` dict: update individual keys:
 
 ```python
 # WRONG
@@ -68,8 +68,8 @@ def on_settings_changed(self):
 
 Settings changes can arrive two ways:
 
-1. **Bus event** (`ovos.skills.settings_changed`) — emitted by `ovos-core`'s file watcher. This is the primary mechanism in a standard setup.
-2. **Local file watcher** — the skill can also watch its own `settings.json` directly. Enabled by setting `monitor_own_settings: true` in the skill's own settings. Useful in isolated setups (e.g. containers) where the skill and core don't share a filesystem.
+1. **Bus event** (`ovos.skills.settings_changed`): emitted by `ovos-core`'s file watcher. This is the primary mechanism in a standard setup.
+2. **Local file watcher**: the skill can also watch its own `settings.json` directly. Enabled by setting `monitor_own_settings: true` in the skill's own settings. Useful in isolated setups (e.g. containers) where the skill and core don't share a filesystem.
 
 ## Remote Settings
 
@@ -78,3 +78,6 @@ Skills can receive remote settings updates via `mycroft.skills.settings.changed`
 ## Private Settings
 
 Skills also have access to `self.private_settings` (`PrivateSettings`), a separate storage for data that should not be shared or synced. Backed by a JSON file outside the standard settings path.
+
+---
+[← resource-files](resource-files.md) · [Home](index.md) · [intent-layers →](intent-layers.md)

--- a/docs/skill-api.md
+++ b/docs/skill-api.md
@@ -1,6 +1,6 @@
-# SkillApi — Inter-Skill RPC
+# SkillApi: Inter-Skill RPC
 
-`SkillApi` provides a MessageBus-based remote procedure call (RPC) mechanism. Methods decorated with `@skill_api_method` are exposed on the bus; any other skill (or application) can call them by fetching a `SkillApi` proxy object.
+`SkillApi` provides a MessageBus-based remote procedure call (RPC) mechanism. Methods decorated with `@skill_api_method` are exposed on the bus. Any other skill (or application) can call them by fetching a `SkillApi` proxy object.
 
 **Source:** `ovos_workshop/skills/api.py`
 
@@ -10,15 +10,14 @@
 
 The bus message protocol for `SkillApi` has two phases:
 
-1. **Discovery** — the caller sends `<skill_id>.public_api` on the bus. The target skill responds with a dict mapping method names to their bus message type and docstring.
-2. **Call** — the caller sends a `Message` of the method's registered type with `{"args": [...], "kwargs": {...}}`. The target skill responds with `{"result": <return value>}`.
+1. **Discovery**: the caller sends `<skill_id>.public_api` on the bus. The target skill responds with a dict mapping method names to their bus message type and docstring.
+2. **Call**: the caller sends a `Message` of the method's registered type with `{"args": [...], "kwargs": {...}}`. The target skill responds with `{"result": <return value>}`.
 
 ---
 
 ## `@skill_api_method` Decorator
 
-`skill_api_method` — `ovos_workshop/decorators/__init__.py:77`
-
+`skill_api_method` is defined in `ovos_workshop/decorators/__init__.py:77`.
 Tag a skill method as part of the public API. The method must be defined on an `OVOSSkill` subclass.
 
 ```python
@@ -38,18 +37,15 @@ The decorator sets `func.api_method = True`. During skill initialization, `OVOSS
 
 ## `SkillApi` Class
 
-`SkillApi` — `ovos_workshop/skills/api.py:20`
-
+`SkillApi` is defined in `ovos_workshop/skills/api.py:20`.
 ### Class Attribute: `bus`
 
-`SkillApi.bus` — `ovos_workshop/skills/api.py:27`
-
+`SkillApi.bus` is defined in `ovos_workshop/skills/api.py:27`.
 A class-level reference to the `MessageBusClient`. Must be set before calling `SkillApi.get()`.
 
 ### `SkillApi.connect_bus(mycroft_bus)`
 
-`SkillApi.connect_bus` — `ovos_workshop/skills/api.py:29`
-
+`SkillApi.connect_bus` is defined in `ovos_workshop/skills/api.py:29`.
 Register the bus client. Call this once during application startup.
 
 ```python
@@ -60,8 +56,7 @@ SkillApi.connect_bus(bus)
 
 ### `SkillApi.get(skill, api_timeout=3)`
 
-`SkillApi.get` — `ovos_workshop/skills/api.py:65`
-
+`SkillApi.get` is defined in `ovos_workshop/skills/api.py:65`.
 Fetches the public API for the given skill and returns a proxy object. Returns `None` if the skill is not running or does not expose any API methods.
 
 ```python
@@ -80,9 +75,8 @@ The returned proxy object has one attribute per exposed method. Calling `proxy.m
 
 ### `SkillApi.__init__(method_dict, timeout=3)`
 
-`SkillApi.__init__` — `ovos_workshop/skills/api.py:34`
-
-Normally you do not construct `SkillApi` directly — use `SkillApi.get()` instead. The constructor builds a dynamic method for every entry in `method_dict`.
+`SkillApi.__init__` is defined in `ovos_workshop/skills/api.py:34`.
+Normally you do not construct `SkillApi` directly. Use `SkillApi.get()` instead. The constructor builds a dynamic method for every entry in `method_dict`.
 
 | Parameter | Description |
 |---|---|
@@ -169,3 +163,6 @@ class MyClientSkill(OVOSSkill):
 
         self.speak(f"It is {temp} degrees in London.")
 ```
+
+---
+[← skill-interaction](skill-interaction.md) · [Home](index.md) · [filesystem →](filesystem.md)

--- a/docs/skill-classes.md
+++ b/docs/skill-classes.md
@@ -37,7 +37,7 @@ See [ovos-skill.md](ovos-skill.md) for full detail.
 
 **Module:** `ovos_workshop.skills.converse`
 
-Extends `OVOSSkill` with explicit converse support — `activate()`, `deactivate()`, and `@conversational_intent` decorated handlers. The skill registers itself in the active-skills list after handling an intent.
+Extends `OVOSSkill` with explicit converse support: `activate()`, `deactivate()`, and `@conversational_intent` decorated handlers. The skill registers itself in the active-skills list after handling an intent.
 
 ```python
 from ovos_workshop.skills.converse import ConversationalSkill
@@ -52,8 +52,8 @@ class MySkill(ConversationalSkill):
 ```
 
 Additional bus events registered:
-- `{skill_id}.converse.ping` — capability advertisement
-- `{skill_id}.converse.request` — converse request from pipeline
+- `{skill_id}.converse.ping`: capability advertisement
+- `{skill_id}.converse.request`: converse request from pipeline
 - `{skill_id}.activate` / `{skill_id}.deactivate`
 - `intent.service.skills.deactivated` / `intent.service.skills.activated`
 
@@ -63,7 +63,7 @@ Additional bus events registered:
 
 **Module:** `ovos_workshop.skills.active`
 
-Extends `ConversationalSkill`. Always present in the converse active-skills list — the skill never deactivates unless explicitly told to. Useful for always-on assistants or global command handlers.
+Extends `ConversationalSkill`. Always present in the converse active-skills list: the skill never deactivates unless explicitly told to. Useful for always-on assistants or global command handlers.
 
 ```python
 from ovos_workshop.skills.active import ActiveSkill
@@ -301,3 +301,6 @@ app = MyApp()  # Creates its own bus connection automatically.
 ```
 
 See [app.md](app.md) for full documentation.
+
+---
+[Home](index.md) · [ovos-skill →](ovos-skill.md)

--- a/docs/skill-interaction.md
+++ b/docs/skill-interaction.md
@@ -12,7 +12,7 @@ OVOSSkill.ask_yesno(prompt: str, data: Optional[dict] = None) -> Optional[str]
 
 Speaks *prompt*, waits for the user's response, and classifies it as `"yes"`, `"no"`, or the raw response string if neither matched.
 
-**Source**: `OVOSSkill.ask_yesno` — `ovos_workshop/skills/ovos.py`
+**Source**: `OVOSSkill.ask_yesno` in `ovos_workshop/skills/ovos.py`
 
 ### Parameters
 
@@ -27,7 +27,7 @@ Speaks *prompt*, waits for the user's response, and classifies it as `"yes"`, `"
 |-------|---------|
 | `"yes"` | User confirmed (e.g. "yeah", "sure", "of course") |
 | `"no"` | User declined (e.g. "nope", "nah", "definitely not") |
-| `str` | User spoke something that could not be classified — raw transcript returned |
+| `str` | User spoke something that could not be classified: raw transcript returned |
 | `None` | No response received (timeout or user said nothing) |
 
 ### Basic usage
@@ -70,16 +70,16 @@ elif answer == "no":
 elif answer is None:
     self.speak_dialog("no_response")
 else:
-    # answer is the raw transcript — user said something unexpected
+    # answer is the raw transcript: user said something unexpected
     self.speak_dialog("did_not_understand")
 ```
 
 ### How it works internally
 
-1. `get_response(dialog=prompt, data=data)` — speaks the prompt, records user reply.
-2. `_get_yesno_engine()` — resolves the plugin name (settings → mycroft.conf → `ovos-solver-yes-no-plugin`), loads it once, and caches it. Falls back to `HeuristicYesNoEngine` if loading fails. `OVOSSkill._get_yesno_engine` — `ovos_workshop/skills/ovos.py:1932`
+1. `get_response(dialog=prompt, data=data)`: speaks the prompt, records user reply.
+2. `_get_yesno_engine()`: resolves the plugin name (settings → mycroft.conf → `ovos-solver-yes-no-plugin`), loads it once, and caches it. Falls back to `HeuristicYesNoEngine` if loading fails. `OVOSSkill._get_yesno_engine`: `ovos_workshop/skills/ovos.py:1932`
 3. `engine.yes_or_no(question=prompt, response=resp, lang=self.lang)` → `True`, `False`, or `None`.
-4. `True` → `"yes"`, `False` → `"no"`, `None`/unmatched → raw response. `OVOSSkill.ask_yesno` — `ovos_workshop/skills/ovos.py:1970`
+4. `True` → `"yes"`, `False` → `"no"`, `None`/unmatched → raw response. `OVOSSkill.ask_yesno`: `ovos_workshop/skills/ovos.py:1970`
 
 ---
 
@@ -98,17 +98,17 @@ OVOSSkill.ask_selection(
 
 Speaks the options list to the user, optionally follows with a dialog prompt, then resolves the user's spoken response to one of the options.
 
-**Source**: `OVOSSkill.ask_selection` — `ovos_workshop/skills/ovos.py`
+**Source**: `OVOSSkill.ask_selection` in `ovos_workshop/skills/ovos.py`
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `options` | `List[str]` | — | The predefined options to offer. |
+| `options` | `List[str]` |: | The predefined options to offer. |
 | `dialog` | `str` | `''` | Dialog ID or literal string spoken **after** the options list. |
 | `data` | `dict \| None` | `None` | Template variables for the dialog string. |
 | `min_conf` | `float` | `0.65` | Minimum fuzzy-match confidence for the default plugin. Passed to the `OptionMatcherEngine` config if no plugin-level config overrides it. |
-| `numeric` | `bool` | `False` | If `True`, speaks each option prefixed with its number ("one, pizza; two, pasta; …"). If `False`, speaks them as a joined list ("pizza, pasta, or salad?"). |
+| `numeric` | `bool` | `False` | If `True`, speaks each option prefixed with its number ("one, pizza, two, pasta, and so on"). If `False`, speaks them as a joined list ("pizza, pasta, or salad?"). |
 | `num_retries` | `int` | `-1` | How many times to re-prompt on no response. `-1` means use the system default. |
 
 ### Return values
@@ -142,10 +142,10 @@ How would you like to travel?
 The skill speaks: *"bus, train, or bicycle? Which would you prefer?"*
 
 The user can say:
-- `"train"` — fuzzy-matched directly
-- `"the second one"` / `"number two"` / `"two"` — position matched
-- `"the last one"` — last-word matched
-- `"option 3"` — numeric matched (requires `ovos-number-parser`)
+- `"train"`: fuzzy-matched directly
+- `"the second one"` / `"number two"` / `"two"`: position matched
+- `"the last one"`: last-word matched
+- `"option 3"`: numeric matched (requires `ovos-number-parser`)
 
 ### Numeric menu
 
@@ -153,7 +153,7 @@ The user can say:
 choice = self.ask_selection(options, numeric=True)
 ```
 
-Speaks each option as: *"one, bus; two, train; three, bicycle"*. Useful when options are long or ambiguous. The user can then say *"two"* or *"the second one"*.
+Speaks each option as: *"one, bus, two, train, three, bicycle"*. Useful when options are long or ambiguous. The user can then say *"two"* or *"the second one"*.
 
 ### Handling None
 
@@ -166,11 +166,11 @@ if choice is None:
 
 ### How it works internally
 
-1. Validates `options` (raises `ValueError` if not a list; returns immediately for 0 or 1 items).
+1. Validates `options` (raises `ValueError` if not a list, returns immediately for 0 or 1 items).
 2. Speaks options (as list or numbered menu based on `numeric`).
-3. `get_response(dialog=dialog, data=data, num_retries=num_retries)` — speaks optional follow-up dialog, records reply.
-4. `_get_selection_engine()` — resolves the plugin name (settings → mycroft.conf → `ovos-option-matcher-fuzzy-plugin`), loads it once, and caches it. Falls back to `FuzzyOptionMatcherPlugin` if loading fails. Sets `engine.config["min_conf"] = min_conf` before calling. `OVOSSkill._get_selection_engine` — `ovos_workshop/skills/ovos.py:1951`
-5. `engine.match_option(utterance=resp, options=options, lang=self.lang)` — resolves response to a slot. `OVOSSkill.ask_selection` — `ovos_workshop/skills/ovos.py:1990`
+3. `get_response(dialog=dialog, data=data, num_retries=num_retries)`: speaks optional follow-up dialog, records reply.
+4. `_get_selection_engine()`: resolves the plugin name (settings → mycroft.conf → `ovos-option-matcher-fuzzy-plugin`), loads it once, and caches it. Falls back to `FuzzyOptionMatcherPlugin` if loading fails. Sets `engine.config["min_conf"] = min_conf` before calling. `OVOSSkill._get_selection_engine`: `ovos_workshop/skills/ovos.py:1951`
+5. `engine.match_option(utterance=resp, options=options, lang=self.lang)`: resolves response to a slot. `OVOSSkill.ask_selection`: `ovos_workshop/skills/ovos.py:1990`
 6. If the engine raises or returns `None`, `ask_selection` returns `None`.
 
 ---
@@ -179,7 +179,7 @@ if choice is None:
 
 Both methods are backed by pluggable agent engines discovered and loaded via [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager).
 
-### ask_yesno — YesNoEngine
+### ask_yesno: YesNoEngine
 
 **Plugin type**: `YesNoEngine` (`opm.agents.yesno`)
 **Config key**: `ask_yesno_plugin`
@@ -201,7 +201,7 @@ The `question` argument gives the plugin context about what was asked, enabling 
 |--------|-------------|
 | `ovos-solver-yes-no-plugin` | Rule-based multilingual yes/no classifier (default fallback) |
 
-### ask_selection — OptionMatcherEngine
+### ask_selection: OptionMatcherEngine
 
 **Plugin type**: `OptionMatcherEngine` (`opm.agents.option_matcher`)
 **Config key**: `ask_selection_plugin`
@@ -224,7 +224,7 @@ def match_option(self, utterance: str, options: List[str], lang: Optional[str] =
 
 ## Configuration
 
-### Global defaults — `mycroft.conf`
+### Global defaults: `mycroft.conf`
 
 ```json
 {
@@ -237,7 +237,7 @@ def match_option(self, utterance: str, options: List[str], lang: Optional[str] =
 
 `ask_yesno_plugin` defaults to `ovos-solver-yes-no-plugin`. `ask_selection_plugin` defaults to `ovos-option-matcher-fuzzy-plugin`. Both packages are installed as runtime dependencies of `ovos-workshop`.
 
-### Per-skill override — `settings.json`
+### Per-skill override: `settings.json`
 
 Place in the skill's `settings.json` to override for that skill only:
 
@@ -351,7 +351,10 @@ Activate system-wide:
 
 ## See also
 
-- [`ovos-solver-yes-no-plugin`](https://github.com/OpenVoiceOS/ovos-solver-YesNo-plugin) — built-in yes/no classifier
-- [`ovos-option-matcher-fuzzy-plugin`](https://github.com/OpenVoiceOS/ovos-option-matcher-fuzzy-plugin) — default selection plugin, with [full docs](https://github.com/OpenVoiceOS/ovos-option-matcher-fuzzy-plugin/tree/master/docs)
-- `OVOSSkill.get_response` — lower-level method used internally by both
-- [OPM agent templates](https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/ovos_plugin_manager/templates/agents.py) — `YesNoEngine`, `OptionMatcherEngine` base classes
+- [`ovos-solver-yes-no-plugin`](https://github.com/OpenVoiceOS/ovos-solver-YesNo-plugin): built-in yes/no classifier
+- [`ovos-option-matcher-fuzzy-plugin`](https://github.com/OpenVoiceOS/ovos-option-matcher-fuzzy-plugin): default selection plugin, with [full docs](https://github.com/OpenVoiceOS/ovos-option-matcher-fuzzy-plugin/tree/master/docs)
+- `OVOSSkill.get_response`: lower-level method used internally by both
+- [OPM agent templates](https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/ovos_plugin_manager/templates/agents.py): `YesNoEngine`, `OptionMatcherEngine` base classes
+
+---
+[← auto-translatable](auto-translatable.md) · [Home](index.md) · [skill-api →](skill-api.md)

--- a/docs/skill-launcher.md
+++ b/docs/skill-launcher.md
@@ -29,17 +29,17 @@ loader.load(MySkillClass)            # instantiates and calls _startup
 ```
 
 Key attributes:
-- `loader.instance` — the live skill instance (or `None` if not loaded)
-- `loader.loaded` — `True` if the skill is currently loaded
-- `loader.active` — `True` if the skill is active (not deactivated)
-- `loader.skill_id` — unique skill identifier
-- `loader.runtime_requirements` — `RuntimeRequirements` from the skill class
+- `loader.instance`: the live skill instance (or `None` if not loaded)
+- `loader.loaded`: `True` if the skill is currently loaded
+- `loader.active`: `True` if the skill is active (not deactivated)
+- `loader.skill_id`: unique skill identifier
+- `loader.runtime_requirements`: `RuntimeRequirements` from the skill class
 
 Key methods:
-- `loader.load(skill_class)` — load and start the skill
-- `loader.reload()` — unload and reload the skill
-- `loader.activate()` — re-enable a deactivated skill
-- `loader.deactivate()` — deactivate (unload) a skill
+- `loader.load(skill_class)`: load and start the skill
+- `loader.reload()`: unload and reload the skill
+- `loader.activate()`: re-enable a deactivated skill
+- `loader.deactivate()`: deactivate (unload) a skill
 
 ## Loading from a File (legacy)
 
@@ -91,7 +91,7 @@ Each `PluginSkillLoader` watches the skill's `settings.json` for external change
 
 `PluginSkillLoader` is how both `ovos-core` (production) and `ovoscope` (testing) load skills.
 ovoscope wraps `SkillManager` in a lightweight `MiniCroft` that uses `FakeBus` instead of a real
-WebSocket bus — skills are loaded identically, so tests exercise the exact same loader path.
+WebSocket bus: skills are loaded identically, so tests exercise the exact same loader path.
 
 ```python
 from ovoscope import End2EndTest, get_minicroft
@@ -121,3 +121,6 @@ minicroft.stop()
 
 For a full tutorial including 8 test patterns and CI integration, see
 [ovoscope/docs/usage-guide.md](../../ovoscope/docs/usage-guide.md).
+
+---
+[← intent-layers](intent-layers.md) · [Home](index.md) · [permissions →](permissions.md)


### PR DESCRIPTION
Rewrites the prose across all pages under docs/ into Simplified Technical English: shorter sentences, active voice, no em dashes or semicolons, and consistent terminology. Adds the standard prev/home/next navigation footer to every docs page, matching the reading order in docs/index.md. No facts, features, or code examples changed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API descriptions, lifecycle guidance, fallback behavior, and testing instructions.
  * Standardized punctuation, headings, formatting, and code examples across the documentation.
  * Added footer navigation links between related guides and the documentation home page.
  * Improved explanations of translation workflows, permissions, settings, resources, and skill interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->