### PR TITLE
fix(ci): coverage workflow installs test skills that no longer exist

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,10 +28,9 @@ jobs:
       run: |
         sudo apt install libssl-dev libfann-dev portaudio19-dev libpulse-dev
         pip install -r requirements/test.txt
-        pip install ./test/end2end/session/skill-ovos-hello-world
-        pip install ./test/end2end/session/skill-ovos-fallback-unknown
-        pip install ./test/end2end/session/skill-ovos-fallback-unknownv1
-        pip install ./test/end2end/session/skill-converse_test
+        # test/end2end/session/ and its four local test skills were removed
+        # long ago; the current end2end tree (intent4/keyword-casing) uses
+        # in-place injected skills that need no install.
     - name: Generate coverage report
       run: |
         pytest --cov=./ovos_workshop --cov-report xml test/unittests


### PR DESCRIPTION
Dev's Run CodeCov fails with `Invalid requirement: './test/end2end/session/skill-ovos-hello-world'` — the coverage workflow still pip-installs four local test skills from a `test/end2end/session/` tree that was deleted long ago (current end2end suites inject their skills in-place). Dropped the four phantom installs.

Note: the simultaneous Repo Health red on dev is a different, org-wide bug — fixed in gh-automations#77.

Dev-breakage sweep by Claude Fable directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the coverage workflow to use the current end-to-end test setup.
  * Removed obsolete test skill installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->