### PR TITLE
fix: enable_intent rebinds the handler after disable_intent

### DIFF
--- a/ovos_workshop/intents.py
+++ b/ovos_workshop/intents.py
@@ -547,6 +547,12 @@ class IntentServiceInterface:
             self.registered_intents.append((name, data))
         else:
             self.registered_intents[slot] = (name, data)
+        # mirror register_intent: a template that had been detach()ed (e.g.
+        # via disable_intent) must be dropped from detached_intents once it
+        # is re-registered, otherwise enable_intent()/intent_is_detached()
+        # keep reporting it as detached forever.
+        self.detached_intents = [detached for detached in self.detached_intents
+                                 if detached[0] != name]
 
     # -- lifecycle ------------------------------------------------------
 
@@ -554,12 +560,21 @@ class IntentServiceInterface:
         msg = dig_for_message() or Message("")
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id
-        if intent_name in self.intent_names:
-            LOG.info(f"Detaching intent: {intent_name}")
-            self.detached_intents.append((intent_name,
-                                          self.get_intent(intent_name)))
+        # registered_intents/detached_intents are keyed by the bare name
+        # (register_intent/register_template strip any "<skill_id>:" prefix
+        # before storing, see register_intent/register_template above).
+        # Callers (e.g. OVOSSkill.disable_intent) may pass either the bare
+        # name or the "<skill_id>:"-prefixed one, so normalize before
+        # matching -- otherwise the prefixed form never matches the bare
+        # key and the intent is never actually detached.
+        prefix = f"{self.skill_id}:"
+        key = intent_name[len(prefix):] if intent_name.startswith(prefix) \
+            else intent_name
+        if key in self.intent_names:
+            LOG.info(f"Detaching intent: {key}")
+            self.detached_intents.append((key, self.get_intent(key)))
             self.registered_intents = [pair for pair in self.registered_intents
-                                       if pair[0] != intent_name]
+                                       if pair[0] != key]
         self.bus.emit(msg.forward(SpecMessage.INTENT_DEREGISTER,
                                   {"skill_id": self.skill_id,
                                    "intent_name": intent_name}))

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -154,6 +154,10 @@ class OVOSSkill:
         # Cached voc file contents
         self._voc_cache = {}
 
+        # remembers the handler bound to each intent name so that
+        # enable_intent() can rebind it after disable_intent() detaches it
+        self._intent_handlers: Dict[str, callable] = {}
+
         # loaded lang file resources
         self._lang_resources = {}
 
@@ -1367,6 +1371,7 @@ class OVOSSkill:
                 slot_blacklist=slot_blacklist,
                 vocabs=resources.vocabularies())
         if handler:
+            self._intent_handlers[intent_file] = handler
             self.add_event(name, handler, 'mycroft.skill.handler',
                            activation=True, is_intent=True)
             # INTENT-4: pipelines are migrating to dispatch on the canonical,
@@ -1602,6 +1607,7 @@ class OVOSSkill:
                                                         self.intent_service.skill_id)
         self.intent_service.register_intent(name, intent_parser)
         if handler:
+            self._intent_handlers[name] = handler
             self.add_event(intent_parser.name, handler,
                            'mycroft.skill.handler',
                            activation=True, is_intent=True)
@@ -2412,11 +2418,17 @@ class OVOSSkill:
         """
         intent = self.intent_service.get_intent(intent_name)
         if intent:
+            handler = self._intent_handlers.get(intent_name)
+            if not handler:
+                self.log.error(f'Could not enable {intent_name}, no handler '
+                               f'is on record for it (was it ever registered '
+                               f'with a handler by this skill instance?).')
+                return False
             if ".intent" in intent_name:
-                self.register_intent_file(intent_name, None)
+                self.register_intent_file(intent_name, handler)
             else:
                 intent.name = intent_name
-                self.register_intent(intent, None)
+                self.register_intent(intent, handler)
             self.log.debug(f'Enabling intent {intent_name}')
             return True
         else:

--- a/test/unittests/skills/test_base.py
+++ b/test/unittests/skills/test_base.py
@@ -598,21 +598,142 @@ class TestOVOSSkill(unittest.TestCase):
             f"{skill.skill_id}:dow_d446b2a6e46e7d94cdf7787e21050ff9",
             uk_samples, "uk-UA", blacklisted_words=[])
 
-    def test_handle_enable_intent(self):
-        # TODO
-        pass
-
-    def test_handle_disable_intent(self):
-        # TODO
-        pass
-
     def test_disable_intent(self):
-        # TODO
-        pass
+        """Regression test: disable_intent() followed by enable_intent()
+        must rebind the ORIGINAL handler for a padatious (.intent file)
+        intent, both for the legacy suffixed topic and the INTENT-4
+        canonical suffix-less topic."""
+        from ovos_bus_client.message import Message
+
+        bus = FakeBus()
+        skill = OVOSSkill(bus=bus, skill_id=self.skill_id)
+        skill._lang_resources = dict()
+        skill.res_dir = join(dirname(__file__), "test_locale")
+        skill.config_core["lang"] = "en-US"
+        skill.config_core["secondary_langs"] = []
+
+        called = Event()
+
+        def handler(message):
+            called.set()
+
+        handler.__name__ = "test_handler"
+        skill.register_intent_file("time.intent", handler)
+
+        legacy_name = f"{skill.skill_id}:time.intent"
+        canonical_name = f"{skill.skill_id}:time"
+
+        # sanity: bound before disabling
+        self.assertTrue(any(n == legacy_name for n, _ in skill.events))
+        self.assertTrue(any(n == canonical_name for n, _ in skill.events))
+
+        self.assertTrue(skill.disable_intent("time.intent"))
+        self.assertFalse(any(n == legacy_name for n, _ in skill.events))
+        self.assertFalse(any(n == canonical_name for n, _ in skill.events))
+        self.assertTrue(skill.intent_service.intent_is_detached("time.intent"))
+
+        self.assertTrue(skill.enable_intent("time.intent"))
+        self.assertTrue(any(n == legacy_name for n, _ in skill.events))
+        self.assertTrue(any(n == canonical_name for n, _ in skill.events))
+        self.assertFalse(skill.intent_service.intent_is_detached("time.intent"))
+
+        called.clear()
+        bus.emit(Message(canonical_name, {}, {}))
+        self.assertTrue(called.wait(2),
+                        "handler was not rebound by enable_intent()")
 
     def test_enable_intent(self):
-        # TODO
-        pass
+        """Regression test: disable_intent() followed by enable_intent()
+        must rebind the ORIGINAL handler for an adapt intent."""
+        from ovos_bus_client.message import Message
+        from ovos_workshop.intents import IntentBuilder
+
+        bus = FakeBus()
+        skill = OVOSSkill(bus=bus, skill_id=self.skill_id)
+        skill.register_vocabulary("hello world", "HelloWorldKeyword",
+                                  lang="en-US")
+
+        called = Event()
+
+        def handler(message):
+            called.set()
+
+        skill.register_intent(
+            IntentBuilder("HelloWorldIntent").require("HelloWorldKeyword"),
+            handler)
+
+        event_name = f"{skill.skill_id}:HelloWorldIntent"
+        self.assertTrue(any(n == event_name for n, _ in skill.events))
+
+        self.assertTrue(skill.disable_intent("HelloWorldIntent"))
+        self.assertFalse(any(n == event_name for n, _ in skill.events))
+        self.assertTrue(
+            skill.intent_service.intent_is_detached("HelloWorldIntent"))
+
+        self.assertTrue(skill.enable_intent("HelloWorldIntent"))
+        self.assertTrue(any(n == event_name for n, _ in skill.events))
+        self.assertFalse(
+            skill.intent_service.intent_is_detached("HelloWorldIntent"))
+
+        called.clear()
+        bus.emit(Message(event_name, {}, {}))
+        self.assertTrue(called.wait(2),
+                        "handler was not rebound by enable_intent()")
+
+    def test_handle_disable_intent(self):
+        """The `mycroft.skill.disable_intent` bus handler disables an
+        intent that belongs to this skill and is currently registered."""
+        from ovos_bus_client.message import Message
+
+        bus = FakeBus()
+        skill = OVOSSkill(bus=bus, skill_id=self.skill_id)
+        skill._lang_resources = dict()
+        skill.res_dir = join(dirname(__file__), "test_locale")
+        skill.config_core["lang"] = "en-US"
+        skill.config_core["secondary_langs"] = []
+        skill.register_intent_file("time.intent", Mock(__name__="test"))
+
+        skill.handle_disable_intent(
+            Message("mycroft.skill.disable_intent",
+                   {"intent_name": "time.intent"}))
+
+        self.assertTrue(skill.intent_service.intent_is_detached("time.intent"))
+        legacy_name = f"{skill.skill_id}:time.intent"
+        self.assertFalse(any(n == legacy_name for n, _ in skill.events))
+
+    def test_handle_enable_intent(self):
+        """The `mycroft.skill.enable_intent` bus handler re-enables an
+        intent that belongs to this skill and is currently detached,
+        rebinding its handler."""
+        from ovos_bus_client.message import Message
+
+        bus = FakeBus()
+        skill = OVOSSkill(bus=bus, skill_id=self.skill_id)
+        skill._lang_resources = dict()
+        skill.res_dir = join(dirname(__file__), "test_locale")
+        skill.config_core["lang"] = "en-US"
+        skill.config_core["secondary_langs"] = []
+
+        called = Event()
+
+        def handler(message):
+            called.set()
+
+        handler.__name__ = "test_handler"
+        skill.register_intent_file("time.intent", handler)
+        skill.disable_intent("time.intent")
+        self.assertTrue(skill.intent_service.intent_is_detached("time.intent"))
+
+        skill.handle_enable_intent(
+            Message("mycroft.skill.enable_intent",
+                   {"intent_name": "time.intent"}))
+
+        self.assertFalse(skill.intent_service.intent_is_detached("time.intent"))
+        canonical_name = f"{skill.skill_id}:time"
+        self.assertTrue(any(n == canonical_name for n, _ in skill.events))
+
+        bus.emit(Message(canonical_name, {}, {}))
+        self.assertTrue(called.wait(2))
 
     def test_set_context(self):
         # TODO


### PR DESCRIPTION
## Root cause

`disable_intent()` followed by `enable_intent()` never actually rebound the handler. Two separate bugs combine:

1. **`ovos_workshop/skills/ovos.py` `enable_intent()`** called `register_intent_file(intent_name, None)` for padatious intents and `register_intent(intent, None)` for adapt intents. Both `register_intent_file` and `_register_adapt_intent` only call `add_event(...)` `if handler:` — passing `None` silently skips rebinding, so the intent was "enabled" bus-side but no callback was ever attached again.
2. **`ovos_workshop/intents.py` `IntentServiceInterface.remove_intent()`** was invoked by `disable_intent()` with the `skill_id`-prefixed name, but `registered_intents`/`detached_intents` are keyed by the bare name (`register_intent`/`register_template` strip the `<skill_id>:` prefix before storing). The prefixed lookup never matched, so the intent was never actually moved into `detached_intents` — the internal disable bookkeeping was already broken before `enable_intent` even ran.
3. While fixing the above and building the regression tests, found that `register_template()` (used by `register_intent_file`) never dropped a re-registered intent from `detached_intents` on re-registration — `register_intent()` (adapt path) already did this. Without it, `intent_is_detached()` kept reporting `True` forever after a padatious `.intent` file was re-enabled.

## Fix

- `OVOSSkill` now remembers each intent's handler in `self._intent_handlers` at registration time (`register_intent_file` / `_register_adapt_intent`), and `enable_intent()` passes that handler back into `register_intent_file`/`register_intent` instead of `None`.
- `IntentServiceInterface.remove_intent()` normalizes away the `<skill_id>:` prefix before matching against the bare-keyed registry.
- `IntentServiceInterface.register_template()` now clears the matching `detached_intents` entry on re-registration, mirroring `register_intent()`.

Public API signatures are unchanged.

Reproduced on `origin/dev` (pre-fix). Found during adversarial review of #500.

## Test plan

- [x] `test/unittests/skills/test_base.py`: implemented the previously-empty `test_enable_intent`, `test_disable_intent`, `test_handle_enable_intent`, `test_handle_disable_intent` stubs as real disable→enable round-trip regression tests, covering both padatious (`.intent` file) and adapt intents — asserting the handler actually fires again after re-enabling.
- [x] Verified all 4 new/filled tests **fail** on unfixed `origin/dev` code (checked out the pre-fix `ovos_workshop/intents.py` and `ovos_workshop/skills/ovos.py` against the new tests): 4 failed, 1 passed.
- [x] With the fix applied: `pytest test/unittests/skills/test_base.py -q` → 72 passed.
- [x] `pytest test/unittests/skills/test_base.py test/unittests/skills/test_ovos.py test/unittests/test_intent4_producer.py test/unittests/skills/test_intent_provider.py test/end2end/test_intent4_producer_e2e.py -q` → 129 passed.

---
🤖 Implemented by Claude (Sonnet), orchestrated by Claude Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)