### PR TITLE
fix: acknowledge converse capability queries

### DIFF
--- a/docs/skill-classes.md
+++ b/docs/skill-classes.md
@@ -25,6 +25,8 @@ OVOSSkill                             ovos_workshop/skills/ovos.py
 
 The universal base class. Every skill and application ultimately inherits from `OVOSSkill`. Handles intent registration, resource files, settings, GUI interface, MessageBus events, and the full skill lifecycle (`initialize`, `default_shutdown`).
 
+Every skill also acknowledges its targeted `{skill_id}.converse.ping` capability query. The base class promptly replies with `can_handle: false`; `ConversationalSkill` overrides that decision. This lets the intent service distinguish a non-conversational skill from an unresponsive one.
+
 ```python
 from ovos_workshop.skills.ovos import OVOSSkill
 ```
@@ -52,7 +54,7 @@ class MySkill(ConversationalSkill):
 ```
 
 Additional bus events registered:
-- `{skill_id}.converse.ping`: capability advertisement
+- `{skill_id}.converse.ping`: capability advertisement, overriding the base decline
 - `{skill_id}.converse.request`: converse request from pipeline
 - `{skill_id}.activate` / `{skill_id}.deactivate`
 - `intent.service.skills.deactivated` / `intent.service.skills.activated`

--- a/ovos_workshop/skills/converse.py
+++ b/ovos_workshop/skills/converse.py
@@ -56,7 +56,6 @@ class ConversationalSkill(OVOSSkill):
 
     def _register_system_event_handlers(self):
         super()._register_system_event_handlers()
-        self.add_event(f"{self.skill_id}.converse.ping", self._handle_converse_ack, speak_errors=False)
         self.add_event(f"{self.skill_id}.converse.request", self._handle_converse_request, speak_errors=False)
         self.add_event(f"{self.skill_id}.activate", self.handle_activate, speak_errors=False)
         self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate, speak_errors=False)

--- a/ovos_workshop/skills/ovos.py
+++ b/ovos_workshop/skills/ovos.py
@@ -1087,6 +1087,7 @@ class OVOSSkill:
         self.add_event('mycroft.stop', self._handle_session_stop, speak_errors=False)
         self.add_event(f"{self.skill_id}.stop", self._handle_session_stop, speak_errors=False)
         self.add_event(f"{self.skill_id}.stop.ping", self._handle_stop_ack, speak_errors=False)
+        self.add_event(f"{self.skill_id}.converse.ping", self._handle_converse_ack, speak_errors=False)
         self.add_event(f"{self.skill_id}.converse.get_response", self.__handle_get_response, speak_errors=False)
 
         self.add_event('mycroft.skill.enable_intent', self.handle_enable_intent, speak_errors=False)
@@ -1167,6 +1168,22 @@ class OVOSSkill:
             "skill.stop.pong",
             data={"skill_id": self.skill_id,
                   "can_handle": self.can_stop(message)},
+            context={"skill_id": self.skill_id}))
+
+    def _handle_converse_ack(self, message: Message):
+        """Decline converse capability for a non-conversational skill.
+
+        The intent service queries every active skill with a targeted
+        ``{skill_id}.converse.ping``.  A base ``OVOSSkill`` cannot converse,
+        but it must still acknowledge that query so the intent service can
+        distinguish a prompt decline from an unresponsive skill.
+
+        ``ConversationalSkill`` overrides this handler and delegates the
+        decision to its ``can_converse`` implementation.
+        """
+        self.bus.emit(message.reply(
+            "skill.converse.pong",
+            data={"skill_id": self.skill_id, "can_handle": False},
             context={"skill_id": self.skill_id}))
 
     def stop_session(self, session: Session) -> bool:
@@ -2574,7 +2591,6 @@ class SkillGUI(GUIInterface):
         ui_directories = get_ui_directories(skill.root_dir)
         GUIInterface.__init__(self, skill_id=skill_id, bus=bus, config=config,
                               ui_directories=ui_directories)
-
 
 
 

--- a/test/unittests/skills/test_converse_extended.py
+++ b/test/unittests/skills/test_converse_extended.py
@@ -110,6 +110,19 @@ class TestConversationalSkillCanConverse(unittest.TestCase):
         self.assertIsInstance(result, bool)
         self.assertTrue(result)
 
+    def test_converse_ping_emits_one_positive_ack(self) -> None:
+        replies = []
+        self.bus.on("skill.converse.pong", replies.append)
+
+        self.bus.emit(Message("converse.test2.converse.ping",
+                              data={"utterances": ["hello"]}))
+
+        self.assertEqual(len(replies), 1)
+        self.assertEqual(replies[0].data, {
+            "skill_id": "converse.test2",
+            "can_handle": True,
+        })
+
 
 class TestConversationalSkillHandlers(unittest.TestCase):
     """Tests for handle_activate and handle_deactivate default no-ops."""

--- a/test/unittests/skills/test_ovos.py
+++ b/test/unittests/skills/test_ovos.py
@@ -1,5 +1,6 @@
 import unittest
 
+from ovos_bus_client.message import Message
 from ovos_utils.process_utils import RuntimeRequirements
 from ovos_utils.fakebus import FakeBus
 from ovos_utils import classproperty
@@ -58,6 +59,23 @@ class TestOVOSSkill(unittest.TestCase):
     def test_activate(self):
         # TODO
         pass
+
+    def test_converse_ping_declines_without_timeout(self):
+        bus = FakeBus()
+        replies = []
+        bus.on("skill.converse.pong", replies.append)
+        skill = OVOSSkill(bus=bus, skill_id="plain.skill")
+
+        bus.emit(Message("plain.skill.converse.ping",
+                         data={"utterances": ["hello"]}))
+
+        self.assertEqual(len(replies), 1)
+        self.assertEqual(replies[0].data, {
+            "skill_id": "plain.skill",
+            "can_handle": False,
+        })
+        self.assertEqual(replies[0].context["skill_id"], "plain.skill")
+        skill.default_shutdown()
 
     def test_deactivate(self):
         # TODO
@@ -186,4 +204,3 @@ class TestOVOSSkill(unittest.TestCase):
         skill = MockSkill()
         self.assertIsInstance(skill, OVOSSkill)
         self.assertNotIsInstance(skill, OVOSAbstractApplication)
-


### PR DESCRIPTION
## What changed

- make every base `OVOSSkill` acknowledge its targeted `{skill_id}.converse.ping` with `can_handle: false`
- keep `ConversationalSkill` as the single override that delegates to `can_converse`
- remove the duplicate subclass event registration so each query produces exactly one pong
- document the capability contract and cover both negative and positive acknowledgements

## Why

The converse pipeline queries active skills and waits up to 500 ms for every acknowledgement. Ordinary `OVOSSkill` implementations do not register the ping topic, so a recently active non-conversational skill is indistinguishable from a hung conversational skill.

A 32-runtime / 400-established-client skill-only canary measured converse matching at 147–178 ms mean across three clean observations, making it the largest matching substage. Padatious exact matches were already cached at 31–39 ms.

This change preserves the existing query protocol and timeout semantics for genuinely unresponsive skills while turning an expected capability decline into an immediate response.

## Impact

- non-conversational skills no longer consume the converse timeout budget on the next utterance
- conversational skills retain their existing `can_converse(message)` behavior
- exactly one `skill.converse.pong` is emitted per targeted query

## Validation

- `pytest -q test/unittests`: 552 passed
- `pytest -q test/end2end`: 10 passed
- targeted skill tests: 28 passed
- `ruff check --ignore E741,F541` on touched Python files: clean (the two ignored findings pre-exist on upstream `dev`)
- `git diff --check`: clean

The PR is intentionally draft until the exact composed canary image confirms the end-to-end latency change.
